### PR TITLE
Added support for synthetizable div/rem instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ include config.mk
 
 # Construct core configuration string (used for directory naming).
 # Note: '?=' not used so string is only constructed once.
-CORE_CONFIG := $(THREADS)t$(if $(findstring true, $(FLEXPRET)),f)-$(ISPM_KBYTES)i-$(DSPM_KBYTES)d$(if $(findstring true, $(MUL)),-mul)-$(SUFFIX)
+CORE_CONFIG := $(THREADS)t$(if $(findstring true, $(FLEXPRET)),f)-$(ISPM_KBYTES)i-$(DSPM_KBYTES)d$(if $(findstring true, $(MUL)),-mul)$(if $(findstring true, $(DIV)),-div)-$(SUFFIX)
 
 # Default will build target and selected programs.
 all: $(TARGET)

--- a/config.mk
+++ b/config.mk
@@ -18,8 +18,8 @@ THREADS ?= 4
 FLEXPRET ?= true
 ISPM_KBYTES ?= 16
 DSPM_KBYTES ?= 16
-MUL ?= true
-DIV ?= true
+MUL ?= false
+DIV ?= false # Synthesizable but at low clock frequency
 SUFFIX ?= ti
 
 # Target

--- a/config.mk
+++ b/config.mk
@@ -18,7 +18,8 @@ THREADS ?= 4
 FLEXPRET ?= true
 ISPM_KBYTES ?= 16
 DSPM_KBYTES ?= 16
-MUL ?= false
+MUL ?= true
+DIV ?= true
 SUFFIX ?= ti
 
 # Target

--- a/src/Core/constants.scala
+++ b/src/Core/constants.scala
@@ -2,7 +2,7 @@
 File: constants.scala
 Description: Constant values for parameters, control signals, and RISC-V ISA.
 Author: Michael Zimmer (mzimmer@eecs.berkeley.edu)
-Contributors: 
+Contributors:
 License: See LICENSE.txt
 ******************************************************************************/
 package Core
@@ -22,7 +22,7 @@ object FlexpretConstants
   val T = Bool(true)
   val F = Bool(false)
   val X = Bits("b?", 1)
-  
+
   // immediate
   val IMM_WI = 3
   val IMM_S  = UInt(0, 3)
@@ -39,7 +39,7 @@ object FlexpretConstants
   val OP1_RS1 = UInt(1, 2)
   val OP1_0   = UInt(2, 2)
   val OP1_X   = Bits("b??", 2)
- 
+
   // ALU op2 select
   val OP2_WI = 2
   val OP2_IMM = UInt(0, 2)
@@ -61,7 +61,7 @@ object FlexpretConstants
   val ALU_SLTU = UInt(11, 4)
   val ALU_SRA  = UInt(13, 4)
   val ALU_X    = Bits("b????", 4)
-  
+
   // branch condition
   val BR_WI = 3
   val BR_EQ  = UInt(0, 3)
@@ -71,21 +71,21 @@ object FlexpretConstants
   val BR_LTU = UInt(4, 3)
   val BR_GEU = UInt(5, 3)
   val BR_X   = Bits("b???", 3)
- 
+
   // CSR types
   val CSR_WI = 2
   val CSR_W = UInt(1, 2)
   val CSR_S = UInt(2, 2)
   val CSR_C = UInt(3, 2)
   val CSR_X = Bits("b??", 2)
-  
+
   // rd from execute stage select
   val EXE_RD_WI = 2
   val EXE_RD_ALU = UInt(0, 2)
   val EXE_RD_CSR = UInt(1, 2)
   val EXE_RD_PC4 = UInt(2, 2)
   val EXE_RD_X   = Bits("b??", 2)
-  
+
   // memory load/store operation types
   val MEM_WI = 4
   val MEM_LB  = UInt(0,  4)
@@ -98,21 +98,25 @@ object FlexpretConstants
   val MEM_SW  = UInt(10, 4)
   val MEM_X   = Bits("b????", 4)
 
-  val MUL_WI = 2
-  val MUL_L   = UInt(0, 2)
-  val MUL_H   = UInt(1, 2)
-  val MUL_HSU = UInt(2, 2)
-  val MUL_HU  = UInt(3, 2)
-  val MUL_X   = Bits("b??", 2)
-  
+  val MUL_WI = 3
+  val MUL_L   = UInt(0, 3)
+  val MUL_H   = UInt(1, 3)
+  val MUL_HSU = UInt(2, 3)
+  val MUL_HU  = UInt(3, 3)
+  val DIV_L   = UInt(4, 3)
+  val DIV_LU = UInt(5, 3)
+  val REM_L   = UInt(6, 3)
+  val REM_LU = UInt(7, 3)
+  val MUL_X   = Bits("b???", 3)
+
   // rd from memory stage select
   val MEM_RD_WI = 2
   val MEM_RD_REG = UInt(0, 2)
   val MEM_RD_MEM = UInt(1, 2)
   val MEM_RD_MUL = UInt(2, 2)
   val MEM_RD_X   = Bits("b??", 2)
-  
-  
+
+
   // ************************************************************
   // Determined by control
 
@@ -136,10 +140,10 @@ object FlexpretConstants
   val RS2_EXE = UInt(1, 2)
   val RS2_MEM = UInt(2, 2)
   val RS2_WB  = UInt(3, 2)
- 
+
   // ************************************************************
   // Constants
-  
+
   // thread scheduling slots
   val SLOT_WI = 4
   val SLOT_T0 = UInt(0, 4)
@@ -178,7 +182,7 @@ object FlexpretConstants
   val ADDR_DSPM_VAL  = Bits("b001", ADDR_DSPM_BITS)
   val ADDR_BUS_BITS  = 2
   val ADDR_BUS_VAL   = Bits("b01", ADDR_BUS_BITS)
-  
+
   // memory protection
   val MEMP_WI = 4
   val MEMP_T0 = UInt(0, 4)

--- a/src/Core/constants.scala
+++ b/src/Core/constants.scala
@@ -111,10 +111,11 @@ object FlexpretConstants
 
   // rd from memory stage select
   val MEM_RD_WI = 2
-  val MEM_RD_REG = UInt(0, 2)
-  val MEM_RD_MEM = UInt(1, 2)
-  val MEM_RD_MUL = UInt(2, 2)
-  val MEM_RD_X   = Bits("b??", 2)
+  val MEM_RD_REG = UInt(0, 3)
+  val MEM_RD_MEM = UInt(1, 3)
+  val MEM_RD_MUL = UInt(2, 3)
+  val MEM_RD_DIV = UInt(3, 3)
+  val MEM_RD_X   = Bits("b???", 3)
 
 
   // ************************************************************

--- a/src/Core/constants.scala
+++ b/src/Core/constants.scala
@@ -110,7 +110,7 @@ object FlexpretConstants
   val MUL_X   = Bits("b???", 3)
 
   // rd from memory stage select
-  val MEM_RD_WI = 2
+  val MEM_RD_WI = 3
   val MEM_RD_REG = UInt(0, 3)
   val MEM_RD_MEM = UInt(1, 3)
   val MEM_RD_MUL = UInt(2, 3)

--- a/src/Core/control.scala
+++ b/src/Core/control.scala
@@ -144,14 +144,14 @@ class Control(implicit conf: FlexpretConfiguration) extends Module
     DIV    -> (if(conf.div) {
               List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   DIV_L,   EXE_RD_X,   MEM_X,   MEM_RD_MUL, T, F, F, F, F, F, F, F, F, F, F, F)
               } else { default }),
-    DIVU    -> (if(conf.div) {
-              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   DIV_LU,   EXE_RD_X,   MEM_X,   MEM_RD_MUL, T, F, F, F, F, F, F, F, F, F, F, F)
+    DIVU   -> (if(conf.div) {
+              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   DIV_LU,   EXE_RD_X,   MEM_X,  MEM_RD_MUL, T, F, F, F, F, F, F, F, F, F, F, F)
               } else { default }),
     REM    -> (if(conf.div) {
               List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   REM_L,   EXE_RD_X,   MEM_X,   MEM_RD_MUL, T, F, F, F, F, F, F, F, F, F, F, F)
               } else { default }),
-    REMU    -> (if(conf.div) {
-              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   REM_LU,   EXE_RD_X,   MEM_X,   MEM_RD_MUL, T, F, F, F, F, F, F, F, F, F, F, F)
+    REMU   -> (if(conf.div) {
+              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   REM_LU,   EXE_RD_X,   MEM_X,  MEM_RD_MUL, T, F, F, F, F, F, F, F, F, F, F, F)
               } else { default }),
     MULH   -> (if(conf.mul) {
               List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   MUL_H,   EXE_RD_X,   MEM_X,   MEM_RD_MUL, T, F, F, F, F, F, F, F, F, F, F, F)

--- a/src/Core/control.scala
+++ b/src/Core/control.scala
@@ -154,13 +154,13 @@ class Control(implicit conf: FlexpretConfiguration) extends Module
               List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   DIV_L,   EXE_RD_X,   MEM_X,   MEM_RD_DIV, T, F, F, F, F, F, F, F, F, F, F, F)
               } else { default }),
     DIVU   -> (if(conf.div) {
-              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   DIV_LU,   EXE_RD_X,   MEM_X,  MEM_RD_DIV, T, F, F, F, F, F, F, F, F, F, F, F)
+              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   DIV_LU,  EXE_RD_X,   MEM_X,   MEM_RD_DIV, T, F, F, F, F, F, F, F, F, F, F, F)
               } else { default }),
     REM    -> (if(conf.div) {
               List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   REM_L,   EXE_RD_X,   MEM_X,   MEM_RD_DIV, T, F, F, F, F, F, F, F, F, F, F, F)
               } else { default }),
     REMU   -> (if(conf.div) {
-              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   REM_LU,   EXE_RD_X,   MEM_X,  MEM_RD_DIV, T, F, F, F, F, F, F, F, F, F, F, F)
+              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   REM_LU,  EXE_RD_X,   MEM_X,   MEM_RD_DIV, T, F, F, F, F, F, F, F, F, F, F, F)
               } else { default }),
     SCALL  -> List(T, IMM_X, OP1_X,   OP2_X,   ALU_X,    BR_X,   CSR_X,   MUL_X,   EXE_RD_X,   MEM_X,   MEM_RD_X,   F, F, F, F, F, F, F, F, T, F, F, F),
     SRET   -> (if(conf.privilegedMode) {

--- a/src/Core/control.scala
+++ b/src/Core/control.scala
@@ -141,18 +141,6 @@ class Control(implicit conf: FlexpretConfiguration) extends Module
     MUL    -> (if(conf.mul) {
               List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   MUL_L,   EXE_RD_X,   MEM_X,   MEM_RD_MUL, T, F, F, F, F, F, F, F, F, F, F, F)
               } else { default }),
-    DIV    -> (if(conf.div) {
-              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   DIV_L,   EXE_RD_X,   MEM_X,   MEM_RD_MUL, T, F, F, F, F, F, F, F, F, F, F, F)
-              } else { default }),
-    DIVU   -> (if(conf.div) {
-              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   DIV_LU,   EXE_RD_X,   MEM_X,  MEM_RD_MUL, T, F, F, F, F, F, F, F, F, F, F, F)
-              } else { default }),
-    REM    -> (if(conf.div) {
-              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   REM_L,   EXE_RD_X,   MEM_X,   MEM_RD_MUL, T, F, F, F, F, F, F, F, F, F, F, F)
-              } else { default }),
-    REMU   -> (if(conf.div) {
-              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   REM_LU,   EXE_RD_X,   MEM_X,  MEM_RD_MUL, T, F, F, F, F, F, F, F, F, F, F, F)
-              } else { default }),
     MULH   -> (if(conf.mul) {
               List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   MUL_H,   EXE_RD_X,   MEM_X,   MEM_RD_MUL, T, F, F, F, F, F, F, F, F, F, F, F)
               } else { default }),
@@ -161,6 +149,18 @@ class Control(implicit conf: FlexpretConfiguration) extends Module
               } else { default }),
     MULHU  -> (if(conf.mul) {
               List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   MUL_HU,  EXE_RD_X,   MEM_X,   MEM_RD_MUL, T, F, F, F, F, F, F, F, F, F, F, F)
+              } else { default }),
+    DIV    -> (if(conf.div) {
+              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   DIV_L,   EXE_RD_X,   MEM_X,   MEM_RD_DIV, T, F, F, F, F, F, F, F, F, F, F, F)
+              } else { default }),
+    DIVU   -> (if(conf.div) {
+              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   DIV_LU,   EXE_RD_X,   MEM_X,  MEM_RD_DIV, T, F, F, F, F, F, F, F, F, F, F, F)
+              } else { default }),
+    REM    -> (if(conf.div) {
+              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   REM_L,   EXE_RD_X,   MEM_X,   MEM_RD_DIV, T, F, F, F, F, F, F, F, F, F, F, F)
+              } else { default }),
+    REMU   -> (if(conf.div) {
+              List(T, IMM_X, OP1_RS1, OP2_RS2, ALU_X,    BR_X,   CSR_X,   REM_LU,   EXE_RD_X,   MEM_X,  MEM_RD_DIV, T, F, F, F, F, F, F, F, F, F, F, F)
               } else { default }),
     SCALL  -> List(T, IMM_X, OP1_X,   OP2_X,   ALU_X,    BR_X,   CSR_X,   MUL_X,   EXE_RD_X,   MEM_X,   MEM_RD_X,   F, F, F, F, F, F, F, F, T, F, F, F),
     SRET   -> (if(conf.privilegedMode) {
@@ -428,6 +428,13 @@ class Control(implicit conf: FlexpretConfiguration) extends Module
   // Make all multiplication instructions take 2 cycles
   if(conf.mul) {
     when(dec_reg_valid && (dec_mem_rd_data_sel === MEM_RD_MUL)) {
+      dec_stall := Bool(true)
+    }
+  }
+
+  // Make all division instructions take 2 cycles
+  if(conf.div) {
+    when(dec_reg_valid && (dec_mem_rd_data_sel === MEM_RD_DIV)) {
       dec_stall := Bool(true)
     }
   }

--- a/src/Core/datapath.scala
+++ b/src/Core/datapath.scala
@@ -279,6 +279,17 @@ class Datapath(implicit conf: FlexpretConfiguration) extends Module
     mem_mul_result := mult.io.result
   }
 
+  // Divider
+  val mem_div_result = UInt()
+  mem_div_result := mem_reg_rd_data // default mem_rd_data
+  if(conf.div) {
+    val div = Module(new Divider())
+    div.io.op1  := exe_reg_op1
+    div.io.op2  := exe_reg_op2
+    div.io.func := io.control.exe_mul_type
+    mem_div_result := div.io.result
+  }
+
   // Load and Store Unit
   // Request in execute stage, response in memory stage.
   val loadstore = Module(new LoadStore())
@@ -371,8 +382,10 @@ class Datapath(implicit conf: FlexpretConfiguration) extends Module
   mem_rd_data := 
     Mux(io.control.mem_rd_data_sel === MEM_RD_MEM, loadstore.io.data_out,
     Mux(io.control.mem_rd_data_sel === MEM_RD_MUL, mem_mul_result, //mul
+    Mux(io.control.mem_rd_data_sel === MEM_RD_DIV, mem_div_result, //div
     // MEM_RD_REG
     mem_reg_rd_data)
+    ) //div
     ) //mul
 
   // Provide inputs to rd port of register file.

--- a/src/Core/divider.scala
+++ b/src/Core/divider.scala
@@ -1,0 +1,74 @@
+/******************************************************************************
+File: divider.scala:
+Description:  Multi-stage divider.
+Author: Nicolas Hili (nicolas.hili@irt-saintexupery.com)
+Contributors:
+License: See LICENSE.txt
+******************************************************************************/
+package Core
+
+import Chisel._
+import FlexpretConstants._
+
+class Divider(implicit conf: FlexpretConfiguration) extends Module {
+  val io = new Bundle {
+    val op1    = Bits(INPUT, 32)
+    val op2    = Bits(INPUT, 32)
+    val func   = UInt(INPUT, 4)
+    val result = Bits(OUTPUT, 32)
+  }
+
+  val op1 = Mux(io.func === DIV_LU || io.func === REM_LU, Cat(Bits(0, 1), io.op1).toSInt, Cat(io.op1(31), io.op1).toSInt)
+  val op2 = Mux(io.func === DIV_LU || io.func === REM_LU, Cat(Bits(0, 1), io.op2).toSInt, Cat(io.op2(31), io.op2).toSInt)
+  val result = Mux(io.func === REM_L || io.func === REM_LU, rem(op1, op2), div(op1, op2));
+
+  // 2 cycle
+  io.result := Reg(next = result)
+
+  def rem(dividend: Bits, divider: Bits) : Bits = {
+    return divider_signed(dividend, divider, Bool(true));
+  }
+
+  def div(dividend : Bits, divider: Bits) : Bits = {
+    return divider_signed(dividend, divider, Bool(false));
+  }
+
+  def divider_signed(dividend: Bits, divider: Bits, isRemainder: Bool) : Bits = {
+
+    val signed_dividend = dividend(32);
+    val signed_divider = divider(32);
+    val signed_quotient = signed_dividend^signed_divider;
+    val signed_remainder = signed_dividend;
+
+    val udividend = Mux(signed_dividend, ~dividend + Bits(1,1), dividend);
+    val udivider = Mux(signed_divider, ~divider + Bits(1,1), divider);
+
+    var result = divider_unsigned(udividend, udivider, isRemainder);
+
+    return Mux((isRemainder && signed_remainder) || (!isRemainder && signed_quotient),
+      ~result + Bits(1,1),
+      result);
+  }
+
+  def divider_unsigned(dividend : Bits, divider: Bits, isRemainder: Bool) : Bits = {
+    var scaled_divider  = Cat(Bits(0,1), divider, Bits(0,31));
+    var temp_remainder  = Cat(Bits(0,32), dividend);
+    var temp_result     = Bits(0, 64);
+    var quotient        = Bits(0,32);
+    var remainder       = Bits(0,32);
+    var temp            = Cat(Bits(1,1), Bits(0,32)); // FIXME: temp is a 33-bit value, otherwise, the last occurence in the for loop fails
+
+    for (i <- 0 until 32) {
+      temp_result = temp_remainder - scaled_divider;
+      quotient = Mux(temp_result(63-i), quotient & (~temp(32,1)), quotient | temp(32,1));
+      temp_remainder = Mux(temp_result(63-i), temp_remainder, temp_result);
+      scaled_divider = scaled_divider >> UInt(1);
+
+      temp = temp >> UInt(1);
+    }
+    remainder = temp_remainder(31,0);
+
+    val result = Mux(isRemainder, remainder, quotient);
+    return result;
+  }
+}

--- a/src/Core/divider.scala
+++ b/src/Core/divider.scala
@@ -54,22 +54,19 @@ class Divider(implicit conf: FlexpretConfiguration) extends Module {
   def divider_unsigned(dividend : Bits, divider: Bits, isRemainder: Bool) : Bits = {
     var scaled_divider  = Cat(Bits(0,1), divider, Bits(0,31));
     var temp_remainder  = Cat(Bits(0,32), dividend);
-    var temp_result     = Bits(0, 64);
     var quotient        = Bits(0,32);
-    var remainder       = Bits(0,32);
-    var temp            = Cat(Bits(1,1), Bits(0,32)); // FIXME: temp is a 33-bit value, otherwise, the last occurence in the for loop fails
+    var temp            = Cat(Bits(1,1), Bits(0,32));
 
     for (i <- 0 until 32) {
-      temp_result = temp_remainder - scaled_divider;
+      val temp_result = temp_remainder - scaled_divider;
       quotient = Mux(temp_result(63-i), quotient & (~temp(32,1)), quotient | temp(32,1));
       temp_remainder = Mux(temp_result(63-i), temp_remainder, temp_result);
       scaled_divider = scaled_divider >> UInt(1);
 
       temp = temp >> UInt(1);
     }
-    remainder = temp_remainder(31,0);
 
-    val result = Mux(isRemainder, remainder, quotient);
+    val result = Mux(isRemainder, temp_remainder(31,0), quotient);
     return result;
   }
 }

--- a/src/Core/multiplier.scala
+++ b/src/Core/multiplier.scala
@@ -2,7 +2,7 @@
 File: multiplier.scala:
 Description:  Multi-stage multiplier.
 Author: Michael Zimmer (mzimmer@eecs.berkeley.edu)
-Contributors: Nicolas Hili (nicolas.hili@irt-saintexupery.com)
+Contributors:
 License: See LICENSE.txt
 ******************************************************************************/
 package Core
@@ -17,60 +17,14 @@ class Multiplier(implicit conf: FlexpretConfiguration) extends Module {
     val func   = UInt(INPUT, 4)
     val result = Bits(OUTPUT, 32)
   }
-
-  val op1 = Mux(io.func === MUL_HU || io.func === DIV_LU || io.func === REM_LU, Cat(Bits(0, 1), io.op1).toSInt, Cat(io.op1(31), io.op1).toSInt)
-  val op2 = Mux(io.func === MUL_HSU || io.func === MUL_HU || io.func === DIV_LU || io.func === REM_LU, Cat(Bits(0, 1), io.op2).toSInt, Cat(io.op2(31), io.op2).toSInt)
-  val mul_result = Mux(io.func === REM_L || io.func === REM_LU, rem(op1, op2),
-                      Mux(io.func === DIV_L || io.func === DIV_LU, div(op1, op2), op1 * op2));
-  val result = Mux(io.func === MUL_L || io.func === DIV_L || io.func === DIV_LU || io.func === REM_L || io.func === REM_LU, mul_result(31, 0), mul_result(63, 32))
+  
+  val op1 = Mux(io.func === MUL_HU, Cat(Bits(0, 1), io.op1).toSInt, Cat(io.op1(31), io.op1).toSInt)
+  val op2 = Mux(io.func === MUL_HSU || io.func === MUL_HU, Cat(Bits(0, 1), io.op2).toSInt, Cat(io.op2(31), io.op2).toSInt)
+  val mul_result = op1 * op2
+  val result = Mux(io.func === MUL_L, mul_result(31, 0), mul_result(63, 32))
 
   // 2 cycle
   io.result := Reg(next = result)
 
-  def rem(dividend: Bits, divider: Bits) : Bits = {
-    return divider_signed(dividend, divider, Bool(true));
-  }
-
-  def div(dividend : Bits, divider: Bits) : Bits = {
-    return divider_signed(dividend, divider, Bool(false));
-  }
-
-  def divider_signed(dividend: Bits, divider: Bits, isRemainder: Bool) : Bits = {
-
-    val signed_dividend = dividend(32);
-    val signed_divider = divider(32);
-    val signed_quotient = signed_dividend^signed_divider;
-    val signed_remainder = signed_dividend;
-
-    val udividend = Mux(signed_dividend, ~dividend + Bits(1,1), dividend);
-    val udivider = Mux(signed_divider, ~divider + Bits(1,1), divider);
-
-    var result = divider_unsigned(udividend, udivider, isRemainder);
-
-    return Mux((isRemainder && signed_remainder) || (!isRemainder && signed_quotient),
-      ~result + Bits(1,1),
-      result);
-  }
-
-  def divider_unsigned(dividend : Bits, divider: Bits, isRemainder: Bool) : Bits = {
-    var scaled_divider  = Cat(Bits(0,1), divider, Bits(0,31));
-    var temp_remainder  = Cat(Bits(0,32), dividend);
-    var temp_result     = Bits(0, 64);
-    var quotient        = Bits(0,32);
-    var remainder       = Bits(0,32);
-    var temp            = Cat(Bits(1,1), Bits(0,32)); // FIXME: temp is a 33-bit value, otherwise, the last occurence in the for loop fails
-
-    for (i <- 0 until 32) {
-      temp_result = temp_remainder - scaled_divider;
-      quotient = Mux(temp_result(63-i), quotient & (~temp(32,1)), quotient | temp(32,1));
-      temp_remainder = Mux(temp_result(63-i), temp_remainder, temp_result);
-      scaled_divider = scaled_divider >> UInt(1);
-
-      temp = temp >> UInt(1);
-    }
-    remainder = temp_remainder(31,0);
-
-    val result = Mux(isRemainder, remainder, quotient);
-    return result;
-  }
 }
+

--- a/src/Core/multiplier.scala
+++ b/src/Core/multiplier.scala
@@ -2,7 +2,7 @@
 File: multiplier.scala:
 Description:  Multi-stage multiplier.
 Author: Michael Zimmer (mzimmer@eecs.berkeley.edu)
-Contributors:
+Contributors: Nicolas Hili (nicolas.hili@irt-saintexupery.com)
 License: See LICENSE.txt
 ******************************************************************************/
 package Core
@@ -17,14 +17,50 @@ class Multiplier(implicit conf: FlexpretConfiguration) extends Module {
     val func   = UInt(INPUT, 4)
     val result = Bits(OUTPUT, 32)
   }
-  
-  val op1 = Mux(io.func === MUL_HU, Cat(Bits(0, 1), io.op1).toSInt, Cat(io.op1(31), io.op1).toSInt)
-  val op2 = Mux(io.func === MUL_HSU || io.func === MUL_HU, Cat(Bits(0, 1), io.op2).toSInt, Cat(io.op2(31), io.op2).toSInt)
-  val mul_result = op1 * op2
-  val result = Mux(io.func === MUL_L, mul_result(31, 0), mul_result(63, 32))
+
+  val op1 = Mux(io.func === MUL_HU || io.func === DIV_LU || io.func === REM_LU, Cat(Bits(0, 1), io.op1).toSInt, Cat(io.op1(31), io.op1).toSInt)
+  val op2 = Mux(io.func === MUL_HSU || io.func === MUL_HU || io.func === DIV_LU || io.func === REM_LU, Cat(Bits(0, 1), io.op2).toSInt, Cat(io.op2(31), io.op2).toSInt)
+  val mul_result = Mux(io.func === REM_L || io.func === REM_LU, rem(op1, op2),
+                      Mux(io.func === DIV_L || io.func === DIV_LU, div(op1, op2), op1 * op2));
+  val result = Mux(io.func === MUL_L || io.func === DIV_L || io.func === DIV_LU || io.func === REM_L || io.func === REM_LU, mul_result(31, 0), mul_result(63, 32))
 
   // 2 cycle
   io.result := Reg(next = result)
 
-}
 
+  // FIXME: synthetisable signed rem operator not yet implemented
+  def rem(dividend: Bits, divider: Bits) : Bits = {
+    return Mux(io.func === REM_LU,
+                divider_unsigned(dividend, divider, Bool(true)),
+                dividend % divider);
+  }
+
+  // FIXME: synthetisable signed div operator not yet implemented
+  def div(dividend : Bits, divider: Bits) : Bits = {
+    return Mux(io.func === DIV_LU,
+                divider_unsigned(dividend, divider, Bool(false)),
+                dividend / divider);
+  }
+
+  def divider_unsigned(dividend : Bits, divider: Bits, isRemainder: Bool) : Bits = {
+    var scaled_divider  = Cat(Bits(0,1), divider, Bits(0,31));
+    var temp_remainder  = Cat(Bits(0,32), dividend);
+    var temp_result     = Bits(0, 64);
+    var quotient        = Bits(0,32);
+    var remainder       = Bits(0,32);
+    var temp            = Cat(Bits(1,1), Bits(0,32)); // FIXME: temp is a 33-bit value, otherwise, the last occurence in the for loop fails
+
+    for (i <- 0 until 32) {
+      temp_result = temp_remainder - scaled_divider;
+      quotient = Mux(temp_result(63-i), quotient & (~temp(32,1)), quotient | temp(32,1));
+      temp_remainder = Mux(temp_result(63-i), temp_remainder, temp_result);
+      scaled_divider = scaled_divider >> UInt(1);
+
+      temp = temp >> UInt(1);
+    }
+    remainder = temp_remainder(31,0);
+
+    val result = Mux(isRemainder, remainder, quotient);
+    return result;
+  }
+}

--- a/tests/isa/div.S
+++ b/tests/isa/div.S
@@ -1,0 +1,74 @@
+#*****************************************************************************
+# div.S
+#-----------------------------------------------------------------------------
+#
+# Test div instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP(2,  div, 0x00000000, 0x00000000, 0x00000001 );
+  TEST_RR_OP(3,  div, 0x00000003, 0x00000020, 0x00000009 );
+  TEST_RR_OP(4,  div, 0x00000004, 0x00000020, 0x00000008 );
+
+  TEST_RR_OP(5,  div, 0x00000000, 0xffffffff, 0xfffffffe );
+  TEST_RR_OP(6,  div, 0x00000003, 0xfffffffd, 0xffffffff );
+  TEST_RR_OP(7,  div, 0x000b93d1, 0xff697e5e, 0xfffffff3 );
+
+  TEST_RR_OP(8,  div, 0x00000000, 0xffffffff, 0x00000002 );
+  TEST_RR_OP(9,  div, 0xfffffffd, 0xfffffffd, 0x00000001 );
+  TEST_RR_OP(10, div, 0xfff46c2f, 0xff697e5e, 0x0000000d );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 11, div, 9, 18, 2 );
+  TEST_RR_SRC2_EQ_DEST( 12, div, 10, 31, 3 );
+  TEST_RR_SRC12_EQ_DEST( 13, div, 1, 18 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 14, 0, div, 9,  18, 2  );
+  TEST_RR_DEST_BYPASS( 15, 1, div, 10, 31, 3  );
+  TEST_RR_DEST_BYPASS( 16, 2, div, 3,  33, 11 );
+
+  TEST_RR_SRC12_BYPASS( 17, 0, 0, div, 9,  18, 2  );
+  TEST_RR_SRC12_BYPASS( 18, 0, 1, div, 10, 31, 3  );
+  TEST_RR_SRC12_BYPASS( 19, 0, 2, div, 3,  33, 11 );
+  TEST_RR_SRC12_BYPASS( 20, 1, 0, div, 9,  18, 2  );
+  TEST_RR_SRC12_BYPASS( 21, 1, 1, div, 10, 31, 3  );
+  TEST_RR_SRC12_BYPASS( 22, 2, 0, div, 3,  33, 11 );
+
+  TEST_RR_SRC21_BYPASS( 23, 0, 0, div, 9,  18, 2  );
+  TEST_RR_SRC21_BYPASS( 24, 0, 1, div, 10, 31, 3  );
+  TEST_RR_SRC21_BYPASS( 25, 0, 2, div, 3,  33, 11 );
+  TEST_RR_SRC21_BYPASS( 26, 1, 0, div, 9,  18, 2  );
+  TEST_RR_SRC21_BYPASS( 27, 1, 1, div, 10, 31, 3  );
+  TEST_RR_SRC21_BYPASS( 28, 2, 0, div, 3,  33, 11 );
+
+  TEST_RR_ZEROSRC1( 29, div, 0, 31 );
+#  TEST_RR_ZEROSRC2( 30, div, 0, 32 ); # division by zero
+#  TEST_RR_ZEROSRC12( 31, div, 0 ); # division by zero
+  TEST_RR_ZERODEST( 32, div, 33, 34 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/tests/isa/divu.S
+++ b/tests/isa/divu.S
@@ -1,0 +1,74 @@
+#*****************************************************************************
+# divu.S
+#-----------------------------------------------------------------------------
+#
+# Test divu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP(2,  divu, 0x00000000, 0x00000000, 0x00000001 );
+  TEST_RR_OP(3,  divu, 0x00000003, 0x00000020, 0x00000009 );
+  TEST_RR_OP(4,  divu, 0x00000004, 0x00000020, 0x00000008 );
+
+  TEST_RR_OP(5,  divu, 0x00000001, 0xffffffff, 0xfffffffe );
+  TEST_RR_OP(6,  divu, 0x00000000, 0xfffffffd, 0xffffffff );
+  TEST_RR_OP(7,  divu, 0x00000000, 0xff697e5e, 0xfffffff3 );
+
+  TEST_RR_OP(8,  divu, 0x7fffffff, 0xffffffff, 0x00000002 );
+  TEST_RR_OP(9,  divu, 0xfffffffd, 0xfffffffd, 0x00000001 );
+  TEST_RR_OP(10, divu, 0x13a5a742, 0xff697e5e, 0x0000000d );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 11, divu, 9, 18, 2 );
+  TEST_RR_SRC2_EQ_DEST( 12, divu, 10, 31, 3 );
+  TEST_RR_SRC12_EQ_DEST( 13, divu, 1, 18 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 14, 0, divu, 9,  18, 2  );
+  TEST_RR_DEST_BYPASS( 15, 1, divu, 10, 31, 3  );
+  TEST_RR_DEST_BYPASS( 16, 2, divu, 3,  33, 11 );
+
+  TEST_RR_SRC12_BYPASS( 17, 0, 0, divu, 9,  18, 2  );
+  TEST_RR_SRC12_BYPASS( 18, 0, 1, divu, 10, 31, 3  );
+  TEST_RR_SRC12_BYPASS( 19, 0, 2, divu, 3,  33, 11 );
+  TEST_RR_SRC12_BYPASS( 20, 1, 0, divu, 9,  18, 2  );
+  TEST_RR_SRC12_BYPASS( 21, 1, 1, divu, 10, 31, 3  );
+  TEST_RR_SRC12_BYPASS( 22, 2, 0, divu, 3,  33, 11 );
+
+  TEST_RR_SRC21_BYPASS( 23, 0, 0, divu, 9,  18, 2  );
+  TEST_RR_SRC21_BYPASS( 24, 0, 1, divu, 10, 31, 3  );
+  TEST_RR_SRC21_BYPASS( 25, 0, 2, divu, 3,  33, 11 );
+  TEST_RR_SRC21_BYPASS( 26, 1, 0, divu, 9,  18, 2  );
+  TEST_RR_SRC21_BYPASS( 27, 1, 1, divu, 10, 31, 3  );
+  TEST_RR_SRC21_BYPASS( 28, 2, 0, divu, 3,  33, 11 );
+
+  TEST_RR_ZEROSRC1( 29, divu, 0, 31 );
+#  TEST_RR_ZEROSRC2( 30, divu, 0, 32 ); # division by zero
+#  TEST_RR_ZEROSRC12( 31, divu, 0 ); # division by zero
+  TEST_RR_ZERODEST( 32, divu, 33, 34 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/tests/isa/rem.S
+++ b/tests/isa/rem.S
@@ -1,0 +1,75 @@
+#*****************************************************************************
+# rem.S
+#-----------------------------------------------------------------------------
+#
+# Test rem instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP(2,  rem, 0x00000000, 0x00000000, 0x00000001 );
+  TEST_RR_OP(3,  rem, 0x00000005, 0x00000020, 0x00000009 );
+  TEST_RR_OP(4,  rem, 0x00000000, 0x00000020, 0x00000008 );
+  TEST_RR_OP(5, rem, 0x00000005, 0x009681A2, 0x0000000d );
+
+  TEST_RR_OP(6,  rem, 0xffffffff, 0xffffffff, 0xfffffffe );
+  TEST_RR_OP(7,  rem, 0x00000000, 0xfffffffd, 0xffffffff );
+
+  TEST_RR_OP(8,  rem, 0xffffffff, 0xffffffff, 0x00000002 );
+  TEST_RR_OP(9,  rem, 0x00000000, 0xfffffffd, 0x00000001 );
+  TEST_RR_OP(10, rem, 0xfffffffb, 0xff697e5e, 0x0000000d );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 11, rem, 0, 18, 2 );
+  TEST_RR_SRC2_EQ_DEST( 12, rem, 1, 31, 3 );
+  TEST_RR_SRC12_EQ_DEST( 13, rem, 0, 18 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 14, 0, rem, 0,  18, 2  );
+  TEST_RR_DEST_BYPASS( 15, 1, rem, 1, 31, 3  );
+  TEST_RR_DEST_BYPASS( 16, 2, rem, 0,  33, 11 );
+
+  TEST_RR_SRC12_BYPASS( 17, 0, 0, rem, 0,  18, 2  );
+  TEST_RR_SRC12_BYPASS( 18, 0, 1, rem, 1, 31, 3  );
+  TEST_RR_SRC12_BYPASS( 19, 0, 2, rem, 0,  33, 11 );
+  TEST_RR_SRC12_BYPASS( 20, 1, 0, rem, 0,  18, 2  );
+  TEST_RR_SRC12_BYPASS( 21, 1, 1, rem, 1, 31, 3  );
+  TEST_RR_SRC12_BYPASS( 22, 2, 0, rem, 0,  33, 11 );
+
+  TEST_RR_SRC21_BYPASS( 23, 0, 0, rem, 0,  18, 2  );
+  TEST_RR_SRC21_BYPASS( 24, 0, 1, rem, 1, 31, 3  );
+  TEST_RR_SRC21_BYPASS( 25, 0, 2, rem, 0,  33, 11 );
+  TEST_RR_SRC21_BYPASS( 26, 1, 0, rem, 0,  18, 2  );
+  TEST_RR_SRC21_BYPASS( 27, 1, 1, rem, 1, 31, 3  );
+  TEST_RR_SRC21_BYPASS( 28, 2, 0, rem, 0,  33, 11 );
+
+  TEST_RR_ZEROSRC1( 29, rem, 0, 31 );
+#  TEST_RR_ZEROSRC2( 30, rem, 0, 32 ); # division by zero
+#  TEST_RR_ZEROSRC12( 31, rem, 0 ); # division by zero
+  TEST_RR_ZERODEST( 32, rem, 33, 34 );
+
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/tests/isa/remu.S
+++ b/tests/isa/remu.S
@@ -1,0 +1,75 @@
+#*****************************************************************************
+# remu.S
+#-----------------------------------------------------------------------------
+#
+# Test remu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP(2,  remu, 0x00000000, 0x00000000, 0x00000001 );
+  TEST_RR_OP(3,  remu, 0x00000005, 0x00000020, 0x00000009 );
+  TEST_RR_OP(4,  remu, 0x00000000, 0x00000020, 0x00000008 );
+  TEST_RR_OP(5,  remu, 0x00000005, 0x009681A2, 0x0000000d );
+
+  TEST_RR_OP(6,  remu, 0x00000001, 0xffffffff, 0xfffffffe );
+  TEST_RR_OP(7,  remu, 0xfffffffd, 0xfffffffd, 0xffffffff );
+
+  TEST_RR_OP(8,  remu, 0x00000001, 0xffffffff, 0x00000002 );
+  TEST_RR_OP(9,  remu, 0x00000000, 0xfffffffd, 0x00000001 );
+  TEST_RR_OP(10, remu, 0x00000004, 0xff697e5e, 0x0000000d );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 11, remu, 0, 18, 2 );
+  TEST_RR_SRC2_EQ_DEST( 12, remu, 1, 31, 3 );
+  TEST_RR_SRC12_EQ_DEST( 13, remu, 0, 18 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 14, 0, remu, 0,  18, 2  );
+  TEST_RR_DEST_BYPASS( 15, 1, remu, 1, 31, 3  );
+  TEST_RR_DEST_BYPASS( 16, 2, remu, 0,  33, 11 );
+
+  TEST_RR_SRC12_BYPASS( 17, 0, 0, remu, 0,  18, 2  );
+  TEST_RR_SRC12_BYPASS( 18, 0, 1, remu, 1, 31, 3  );
+  TEST_RR_SRC12_BYPASS( 19, 0, 2, remu, 0,  33, 11 );
+  TEST_RR_SRC12_BYPASS( 20, 1, 0, remu, 0,  18, 2  );
+  TEST_RR_SRC12_BYPASS( 21, 1, 1, remu, 1, 31, 3  );
+  TEST_RR_SRC12_BYPASS( 22, 2, 0, remu, 0,  33, 11 );
+
+  TEST_RR_SRC21_BYPASS( 23, 0, 0, remu, 0,  18, 2  );
+  TEST_RR_SRC21_BYPASS( 24, 0, 1, remu, 1, 31, 3  );
+  TEST_RR_SRC21_BYPASS( 25, 0, 2, remu, 0,  33, 11 );
+  TEST_RR_SRC21_BYPASS( 26, 1, 0, remu, 0,  18, 2  );
+  TEST_RR_SRC21_BYPASS( 27, 1, 1, remu, 1, 31, 3  );
+  TEST_RR_SRC21_BYPASS( 28, 2, 0, remu, 0,  33, 11 );
+
+  TEST_RR_ZEROSRC1( 29, remu, 0, 31 );
+#  TEST_RR_ZEROSRC2( 30, remu, 0, 32 ); # division by zero
+#  TEST_RR_ZEROSRC12( 31, remu, 0 ); # division by zero
+  TEST_RR_ZERODEST( 32, remu, 33, 34 );
+
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/tests/isa/test.mk
+++ b/tests/isa/test.mk
@@ -22,6 +22,7 @@ PROG= \
 	sub \
 	xor xori \
 	$(if $(findstring true, $(MUL)), mul mulh mulhu mulhsu) \
+	$(if $(findstring true, $(DIV)), div divu rem remu) \
 	$(if $(findstring ex, $(SUFFIX)), $(PROG_EX)) \
 	$(if $(findstring ti, $(SUFFIX)), $(PROG_TI)) \
 	$(if $(findstring all, $(SUFFIX)), $(PROG_ALL)) \
@@ -38,7 +39,7 @@ PROG_TI= \
 PROG_ALL= \
 	$(PROG_TI) \
 
-	
+
 #s_csr \
 #exc_priv \
 #flex_gpio


### PR DESCRIPTION
Hi,

I've added support for div/rem instructions into FlexPRET. instructions with unsigned operators (divu/remu) are implemented in a synthetizable way. Instructions with signed operators (div/rem) are not yet synthetizable and use Chisel classical operators for division and modulo;

[EDIT]: commit 2d8d738 adds support for synthetizable signed instructions (div/rem) in addition to unsigned instructions (divu/remu).

A new parameter "DIV" has been introduced into the Makefile so division is only added when DIV is true. Besides, four examples are available under tests/isa/

It would be great if you consider merging this feature.

Best,

Nicolas Hili