### PR TITLE
Fix the read-under-write behavior of register file

### DIFF
--- a/src/main/scala/Core/RegisterFile.scala
+++ b/src/main/scala/Core/RegisterFile.scala
@@ -8,7 +8,7 @@ License: See LICENSE.txt
 package flexpret.core
 
 import chisel3._
-import chisel3.util.{Cat, log2Ceil, MuxLookup}
+import chisel3.util.{Cat, log2Ceil, MuxLookup, MuxCase}
 import Core.FlexpretConstants._
 import chisel3.experimental.chiselName
 
@@ -61,19 +61,22 @@ class RegisterFile(val threads: Int, val readPorts: Int = 2, val writePorts: Int
       0.U
     )
 
+    // FIXME: Shaokai: Looks suspicious.
     // Account for read-under-write.
     // If there was read-under-write, use the write port's value.
     // We also need to register the data and addresses since we are returning
     // last cycle's requests.
     val readUnderWrites = (writeIndexes zip io.write).map { case (writeIndex, writePort) =>
-      (RegNext(writeIndex) -> RegNext(writePort.data))
+      (RegNext(writeIndex) ->
+        MuxCase(RegNext(writePort.data), Array(
+        RegNext(writePort.addr === 0.U) -> 0.U,
+        RegNext(!writePort.enable) -> regfileRead
+      )))
     }
 
     val readIndexReg = RegNext(readIndex)
-    readPort.data := MuxLookup(readIndexReg, regfileRead, Array(
-      // Reading register 0
-      (0.U -> 0.U)
-    ) ++ readUnderWrites)
+    readPort.data := MuxLookup(readIndexReg, regfileRead, readUnderWrites)
+
   }
 
   // Write ports

--- a/src/main/scala/Core/RegisterFile.scala
+++ b/src/main/scala/Core/RegisterFile.scala
@@ -61,7 +61,6 @@ class RegisterFile(val threads: Int, val readPorts: Int = 2, val writePorts: Int
       0.U
     )
 
-    // FIXME: Shaokai: Looks suspicious.
     // Account for read-under-write.
     // If there was read-under-write, use the write port's value.
     // We also need to register the data and addresses since we are returning


### PR DESCRIPTION
This PR uses the solution from @agrn to fix the read-under-write behavior of the register file.
A corresponding test case has been added to the unit test.