### PR TITLE
Printing cycle by cycle statements

### DIFF
--- a/scripts/hdl/simify_verilog.py
+++ b/scripts/hdl/simify_verilog.py
@@ -40,14 +40,10 @@ def add_cycle(contents: str) -> str:
 
     orig_str = m.group()
     new_str = f"""
-initial begin
-  $value$plusargs("cycle=%s", cycle);
-  // $display("+cycle = %s", cycle);
-end
 
 always @(posedge clock) begin
 
-  if (cycle == "true") begin
+  if (1'($test$plusargs("cycle"))) begin
     // the default tid is 0
     $display("[0] pc = [0x%h] inst = [0x%h] DASM(0x%h)", exe_reg_pc, dec_reg_inst, dec_reg_inst);
   end

--- a/scripts/hdl/simify_verilog.py
+++ b/scripts/hdl/simify_verilog.py
@@ -124,3 +124,4 @@ def main(args: List[str]) -> int:
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))
+    

--- a/scripts/hdl/simify_verilog.py
+++ b/scripts/hdl/simify_verilog.py
@@ -124,4 +124,3 @@ def main(args: List[str]) -> int:
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))
-    

--- a/scripts/hdl/simify_verilog.py
+++ b/scripts/hdl/simify_verilog.py
@@ -101,9 +101,6 @@ end
 
     return contents.replace(orig_str, f"{orig_str} {vcd_blob}")
 
-'''
-args = ['scripts/hdl/simify_verilog.py', 'build/Core.raw.v']
-'''
 def main(args: List[str]) -> int:
     if len(args) < 2:
         print(f"Usage: {args[0]} Core.v", file=sys.stderr)


### PR DESCRIPTION
You can print cycle by cycle statements if you type `+cycle` in the command line.
For example, if you type `fp-emu +ispm=Minimal.hex +cycle 2>&1 | spike-dasm > output.log`, you can get the output.log like this.
<img width="684" alt="image" src="https://user-images.githubusercontent.com/83784897/184255579-7ce05cb9-7394-41e2-8fa8-ebc6d0abc179.png">
