### PR TITLE
Fix Chisel error when threads > 3 and support realloc()

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "programs/lib/tinyalloc"]
 	path = programs/lib/tinyalloc
-	url = https://github.com/thi-ng/tinyalloc.git
+	url = https://github.com/SundayRX/tinyalloc.git

--- a/programs/lib/startup.c
+++ b/programs/lib/startup.c
@@ -25,10 +25,20 @@ void *malloc(size_t size) {
 }
 
 /**
- * Allocate a requested memory and return a pointer to it.
+ * Allocate a requested memory, initial the memory to 0,
+ * and return a pointer to it.
  */
 void *calloc(size_t nitems, size_t size) {
     return ta_calloc(nitems, size);
+}
+
+/**
+ * resize the memory block pointed to by ptr
+ * that was previously allocated with a call
+ * to malloc or calloc.
+ */
+void *realloc(void *ptr, size_t size) {
+    return ta_realloc(ptr, size);
 }
 
 /**

--- a/programs/tests/Makefrag-tests
+++ b/programs/tests/Makefrag-tests
@@ -6,6 +6,7 @@ basic-c-tests = \
 	fib \
 	malloc \
 	calloc \
+    realloc \
 	lbu \
 	global \
 	syscall \

--- a/programs/tests/Makefrag-tests
+++ b/programs/tests/Makefrag-tests
@@ -6,7 +6,7 @@ basic-c-tests = \
 	fib \
 	malloc \
 	calloc \
-    realloc \
+	realloc \
 	lbu \
 	global \
 	syscall \

--- a/programs/tests/c-tests/realloc/realloc.c
+++ b/programs/tests/c-tests/realloc/realloc.c
@@ -1,0 +1,22 @@
+// Example from https://www.geeksforgeeks.org/g-fact-66/
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <flexpret_io.h>
+
+int main() {
+	int *ptr = (int *)malloc(sizeof(int)*2);
+	int i;
+	int *ptr_new;
+		
+	*ptr = 1;
+	*(ptr + 1) = 2;
+		
+	ptr_new = (int *)realloc(ptr, sizeof(int)*3);
+	*(ptr_new + 2) = 3;
+	for(i = 0; i < 3; i++)
+		_fp_print(*(ptr_new + i));
+
+	return 0;
+}
+

--- a/src/main/scala/Core/control.scala
+++ b/src/main/scala/Core/control.scala
@@ -520,7 +520,7 @@ class Control(implicit val conf: FlexpretConfiguration) extends Module
   if(!conf.bypassing) {
     exe_flush := false.B
     dec_stall := false.B
-    stall_count := 0.U // until any logic needs >= 3
+    stall_count(io.exe_tid) := 0.U
   }
 
   // stats


### PR DESCRIPTION
This PR fixes a Chisel error when threads > 3 and supports `realloc()`.