### PR TITLE
Implement thread_cancel() like pthreads

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,17 +56,17 @@ To run a basic Fibonnaci example in simulation, run:
 # cd into the fib directory.
 cd programs/tests/c-tests/fib/
 
-# Compile the program.
-../../../../scripts/c/riscv_compile.sh fib fib.c
+# Compile the program (assume FlexPRET is built with 1 hardware thread).
+../../../../scripts/c/riscv-compile.sh 1 fib fib.c
 
 # Run the simulation.
 ../../../../emulator/fp-emu +ispm=fib.mem
 
 # Clean the generated files.
-../../../../scripts/c/riscv_clean.sh
+../../../../scripts/c/riscv-clean.sh
 ```
 
-We recommend adding `scripts/c/` and `emulator/` to PATH so that `riscv_compile.sh` and `fp-emu` become directly accessible.
+We recommend adding `scripts/c/` and `emulator/` to PATH so that `riscv-compile.sh` and `fp-emu` become directly accessible.
 
 # Directory Structure
 - `build/` Temporary folder used as part of the build

--- a/emulator/emulator.mk
+++ b/emulator/emulator.mk
@@ -14,4 +14,4 @@ $(EMULATOR_BIN): $(VERILOG_RAW) $(EMULATOR_DIR)/main.cpp $(HDL_SCRIPTS)/simify_v
 
 	cp $(EMULATOR_DIR)/obj_dir/VCore $(EMULATOR_BIN)
 
-	echo "Emulator usage: Run '$(EMULATOR_BIN) +ispm=<name>.mem'. A .mem file can be generated using 'scripts/c/riscv_compile.sh <binary name> <C files...>'. The emulation will generate a VCD in Core.vcd. Use flexpret_io.h to print or to terminate simulation."
+	echo "Emulator usage: Run '$(EMULATOR_BIN) +ispm=<name>.mem'. A .mem file can be generated using 'scripts/c/riscv_compile.sh <thread count> <binary name> <C files...>'. The emulation will generate a VCD in Core.vcd. Use flexpret_io.h to print or to terminate simulation."

--- a/programs/lib/flexpret_thread.c
+++ b/programs/lib/flexpret_thread.c
@@ -5,13 +5,13 @@
 #include <flexpret_thread.h>
 
 /* Arrays that keep track of the status of threads */
-void*   (*routines[NUM_THREADS])(void *); // An array of function pointers
-void**  args[NUM_THREADS];
-bool    cancel_requested[NUM_THREADS];
-bool    exit_requested[NUM_THREADS];
-void**  exit_code[NUM_THREADS];
-bool    in_use[NUM_THREADS]; // Whether a thread is currently executing a routine.
-jmp_buf envs[NUM_THREADS];
+static void*   (*routines[NUM_THREADS])(void *); // An array of function pointers
+static void**  args[NUM_THREADS];
+static void**  exit_code[NUM_THREADS];
+static bool    in_use[NUM_THREADS]; // Whether a thread is currently executing a routine.
+static jmp_buf envs[NUM_THREADS];
+static bool    cancel_requested[NUM_THREADS];
+       bool    exit_requested[NUM_THREADS]; // Accessed in startup.c
 
 // Keep track of the number of threads
 // currently processing routines.

--- a/programs/lib/include/flexpret_thread.h
+++ b/programs/lib/include/flexpret_thread.h
@@ -19,4 +19,5 @@ int thread_map(
 int thread_join(thread_t thread, void **retval);
 void thread_exit(void *retval);
 int thread_cancel(thread_t thread);
+void thread_testcancel();
 void worker_main();

--- a/programs/tests/mt-c-tests/add/add.c
+++ b/programs/tests/mt-c-tests/add/add.c
@@ -40,11 +40,6 @@ int main() {
 
     _fp_print(*num);
 
-    // Terminate by having thread 0 send
-    // cancellation requests to all hardware threads.
-    for (int i = 0; i < NUM_THREADS; i++)
-        thread_cancel(i);
-
     return 0;
 }
 

--- a/programs/tests/mt-c-tests/lockowner/lockowner.c
+++ b/programs/tests/mt-c-tests/lockowner/lockowner.c
@@ -39,11 +39,6 @@ int main() {
     void * exit_code_t2;
     thread_join(tid[1], &exit_code_t2);
 
-    // Terminate by having thread 0 send
-    // cancellation requests to all hardware threads.
-    for (int i = 0; i < NUM_THREADS; i++)
-        thread_cancel(i);
-
     return 0;
 }
 

--- a/programs/tests/mt-c-tests/swlock/swlock.c
+++ b/programs/tests/mt-c-tests/swlock/swlock.c
@@ -42,11 +42,6 @@ int main() {
 
     _fp_print(*num);
 
-    // Terminate by having thread 0 send
-    // cancellation requests to all hardware threads.
-    for (int i = 0; i < NUM_THREADS; i++)
-        thread_cancel(i);
-
     return 0;
 }
 

--- a/programs/tests/mt-c-tests/threadcancel/threadcancel.c
+++ b/programs/tests/mt-c-tests/threadcancel/threadcancel.c
@@ -1,0 +1,47 @@
+/* A threaded version of add.c */
+#include <stdlib.h>
+#include <stdint.h>
+#include <flexpret_io.h>
+#include <flexpret_lock.h>
+#include <flexpret_thread.h>
+
+lock_t lock = LOCK_INITIALIZER;
+bool ready = false;
+
+// Intentionally map the do_work functions to
+// two different threads.
+thread_t tid[2] = {1, 2};
+
+// t1 to be canceled by t2
+void* t1_do_work() {
+    lock_acquire(&lock);
+    ready = true;
+    lock_release(&lock);
+    while(1) {
+        thread_testcancel();
+    }
+    _fp_print(111); // Not reachable.
+}
+
+// t2 to cancel t1
+void* t2_do_work() {
+    while(!ready);
+    thread_cancel(tid[0]);
+    _fp_print(222);
+}
+
+int main() {
+
+    int errno = thread_map(&tid[0], t1_do_work, NULL);
+    if (errno != 0) _fp_print(666);
+    errno = thread_map(&tid[1], t2_do_work, NULL);
+    if (errno != 0) _fp_print(666);
+
+    void * exit_code_t1;
+    void * exit_code_t2;
+    thread_join(tid[0], &exit_code_t1);
+    thread_join(tid[1], &exit_code_t2);
+
+    return 0;
+}
+


### PR DESCRIPTION
This PR corrects a previous `thread_cancel()` implementation and makes `thread_cancel()` behave like `pthread_cancel()` in pthreads. The user is also given a `thread_testcancel()` to manually add cancellation points, just like `pthread_testcancel()` does.

This PR also updates the startup code so that all hardware threads terminate when the main thread returns. The user no longer has to manually call `thread_cancel()` at the end of every program.