### PR TITLE
Rollback putting threads to sleep

### DIFF
--- a/programs/lib/startup.c
+++ b/programs/lib/startup.c
@@ -28,7 +28,7 @@ extern uint32_t end;
 
 /* Threading */
 static bool     __ready__;
-static bool     sleep_requested[NUM_THREADS] = {false};
+// static bool     sleep_requested[NUM_THREADS] = {false};
 extern bool     exit_requested[NUM_THREADS];
 extern uint32_t num_threads_busy;
 extern uint32_t num_threads_exited;
@@ -141,18 +141,17 @@ void Reset_Handler() {
 
         // Wait for a worker thread to signal
         // ready-to-sleep and put it to sleep.
-        // FIXME: Mysterious bug
-        int num_sleeping = 0;
-        while (num_sleeping < NUM_THREADS - 1) {
-            for(int i = 1; i < NUM_THREADS; i++) {
-                hwlock_acquire();
-                if (sleep_requested[i]) {
-                    tmode_sleep(i);
-                    num_sleeping++;
-                }
-                hwlock_release();
-            }
-        }
+        // int num_sleeping = 0;
+        // while (num_sleeping < NUM_THREADS - 1) {
+        //     for(int i = 1; i < NUM_THREADS; i++) {
+        //         hwlock_acquire();
+        //         if (sleep_requested[i]) {
+        //             tmode_sleep(i);
+        //             num_sleeping++;
+        //         }
+        //         hwlock_release();
+        //     }
+        // }
 
         // Signal everything is ready.
         hwlock_acquire();
@@ -160,9 +159,9 @@ void Reset_Handler() {
         hwlock_release();
     } else {
         // Signal thread 0 to put the worker thread to sleep.
-        hwlock_acquire();
-        sleep_requested[hartid] = true;
-        hwlock_release();
+        // hwlock_acquire();
+        // sleep_requested[hartid] = true;
+        // hwlock_release();
 
         // Wait for thread 0 to finish setup.
         while (!__ready__);

--- a/programs/lib/startup.c
+++ b/programs/lib/startup.c
@@ -28,7 +28,6 @@ extern uint32_t end;
 
 /* Threading */
 static bool     __ready__;
-// static bool     sleep_requested[NUM_THREADS] = {false};
 extern bool     exit_requested[NUM_THREADS];
 extern uint32_t num_threads_busy;
 extern uint32_t num_threads_exited;
@@ -139,29 +138,16 @@ void Reset_Handler() {
         slot_set(slots, 8);
         hwlock_release();
 
-        // Wait for a worker thread to signal
+        // FIXME: Wait for a worker thread to signal
         // ready-to-sleep and put it to sleep.
-        // int num_sleeping = 0;
-        // while (num_sleeping < NUM_THREADS - 1) {
-        //     for(int i = 1; i < NUM_THREADS; i++) {
-        //         hwlock_acquire();
-        //         if (sleep_requested[i]) {
-        //             tmode_sleep(i);
-        //             num_sleeping++;
-        //         }
-        //         hwlock_release();
-        //     }
-        // }
 
         // Signal everything is ready.
         hwlock_acquire();
         __ready__ = true;
         hwlock_release();
     } else {
-        // Signal thread 0 to put the worker thread to sleep.
-        // hwlock_acquire();
-        // sleep_requested[hartid] = true;
-        // hwlock_release();
+        // FIXME: Signal thread 0 to put
+        // the worker thread to sleep.
 
         // Wait for thread 0 to finish setup.
         while (!__ready__);
@@ -186,8 +172,8 @@ void Reset_Handler() {
         hwlock_acquire();
         for (int i = 1; i < NUM_THREADS; i++) {
             exit_requested[i] = true;
-            // Wake up the thread.
-            tmode_active(i);
+            // FIXME: If the thread is sleeping,
+            // wake up the thread.
         }
         hwlock_release();
 


### PR DESCRIPTION
As #56, #52, and #53 point out, the current mechanism for putting threads to sleep is problematic due to a race condition between hardware and software, as well as the issue of non-atomic update to `tmodes`. This PR rolls back some of the changes that put threads to sleep dynamically and leave them as FIXMEs.