### PR TITLE
Makefile-based build system

### DIFF
--- a/Makefrag
+++ b/Makefrag
@@ -1,0 +1,43 @@
+# FLEXPRET_ROOT_DIR and NAME must be defined
+
+LIB_DIR := $(FLEXPRET_ROOT_DIR)/programs/lib
+LINKER_SCRIPT := $(LIB_DIR)/linker/flexpret.ld
+CC := riscv32-unknown-elf-gcc
+OBJDUMP := riscv32-unknown-elf-objdump
+OBJCOPY := riscv32-unknown-elf-objcopy
+EMU := $(FLEXPRET_ROOT_DIR)/emulator/fp-emu
+
+NUM_THREADS ?= 1 # default number of threads
+
+.PHONY: compile riscv dump mem run clean
+
+compile: riscv dump mem
+
+riscv: $(NAME).riscv
+%.riscv: *.c
+	$(CC) -I$(LIB_DIR)/include -T $(LINKER_SCRIPT) -Xlinker -Map=output.map \
+     -DNUM_THREADS=$(NUM_THREADS) -g -static -O0 -march=rv32i -mabi=ilp32 \
+     -nostartfiles --specs=nosys.specs -o $*.riscv $(LIB_DIR)/start.S \
+     $(LIB_DIR)/syscalls.c $(LIB_DIR)/tinyalloc/tinyalloc.c $(LIB_DIR)/startup.c \
+     $(LIB_DIR)/flexpret_thread.c $(LIB_DIR)/flexpret_lock.c *.c
+
+
+dump: $(NAME).dump
+%.dump: %.riscv
+	$(OBJDUMP) -S -d $*.riscv > $*.dump
+
+
+mem: $(NAME).mem
+%.mem: %.riscv
+	$(OBJCOPY) -O binary $*.riscv $*.binary.txt
+	xxd -c 4 -e $*.binary.txt | cut -c11-18 > $*.mem
+	xxd -c 4 -e $*.binary.txt > $*.mem.orig
+	rm $*.binary.txt
+
+
+run: $(NAME).mem
+	$(EMU) +ispm=$^;
+
+
+clean:
+	rm -f *.vcd *.mem *.riscv *.map *.out *.dump *.orig

--- a/Makefrag
+++ b/Makefrag
@@ -1,5 +1,6 @@
 
-# FLEXPRET_ROOT_DIR and NAME must be defined in the Makefile that this is included from
+# FLEXPRET_ROOT_DIR, NAME, and APP_SOURCES must be defined in the Makefile that this is included from
+
 ifndef FLEXPRET_ROOT_DIR
 $(error FLEXPRET_ROOT_DIR is not set)
 endif
@@ -15,11 +16,11 @@ endif
 
 LIB_DIR ?= $(FLEXPRET_ROOT_DIR)/programs/lib
 LIB_SOURCES ?= $(LIB_DIR)/start.S \
-			   $(LIB_DIR)/syscalls.c \
-			   $(LIB_DIR)/tinyalloc/tinyalloc.c \
-			   $(LIB_DIR)/startup.c \
-			   $(LIB_DIR)/flexpret_thread.c \
-			   $(LIB_DIR)/flexpret_lock.c
+               $(LIB_DIR)/syscalls.c \
+               $(LIB_DIR)/tinyalloc/tinyalloc.c \
+               $(LIB_DIR)/startup.c \
+               $(LIB_DIR)/flexpret_thread.c \
+               $(LIB_DIR)/flexpret_lock.c
 
 NUM_THREADS ?= 1 # number of threads that resulting program will run on
 CFLAGS ?= -g -static -O0 -march=rv32i -mabi=ilp32 -nostartfiles --specs=nosys.specs
@@ -41,7 +42,7 @@ compile: riscv dump mem
 riscv: $(NAME).riscv
 %.riscv: $(LIB_SOURCES) $(APP_SOURCES)
 	$(CC) -I$(LIB_DIR)/include -T $(LINKER_SCRIPT) -Xlinker -Map=$(NAME).map \
-     -DNUM_THREADS=$(NUM_THREADS) $(CFLAGS) -o $*.riscv $^
+	-DNUM_THREADS=$(NUM_THREADS) $(CFLAGS) -o $*.riscv $^
 
 # Generates a dump file for debugging
 dump: $(NAME).dump

--- a/Makefrag
+++ b/Makefrag
@@ -1,43 +1,65 @@
-# FLEXPRET_ROOT_DIR and NAME must be defined
 
-LIB_DIR := $(FLEXPRET_ROOT_DIR)/programs/lib
+# FLEXPRET_ROOT_DIR and NAME must be defined in the Makefile that this is included from
+ifndef FLEXPRET_ROOT_DIR
+$(error FLEXPRET_ROOT_DIR is not set)
+endif
+
+ifndef NAME
+$(error NAME (name of program) is not set)
+endif
+
+ifndef APP_SOURCES
+$(error APP_SOURCES is not set)
+endif
+
+
+LIB_DIR ?= $(FLEXPRET_ROOT_DIR)/programs/lib
+LIB_SOURCES ?= $(LIB_DIR)/start.S \
+			   $(LIB_DIR)/syscalls.c \
+			   $(LIB_DIR)/tinyalloc/tinyalloc.c \
+			   $(LIB_DIR)/startup.c \
+			   $(LIB_DIR)/flexpret_thread.c \
+			   $(LIB_DIR)/flexpret_lock.c
+
+NUM_THREADS ?= 1 # number of threads that resulting program will run on
+CFLAGS ?= -g -static -O0 -march=rv32i -mabi=ilp32 -nostartfiles --specs=nosys.specs
+
 LINKER_SCRIPT := $(LIB_DIR)/linker/flexpret.ld
-CC := riscv32-unknown-elf-gcc
-OBJDUMP := riscv32-unknown-elf-objdump
-OBJCOPY := riscv32-unknown-elf-objcopy
-EMU := $(FLEXPRET_ROOT_DIR)/emulator/fp-emu
+RISCV_PREFIX := riscv32-unknown-elf-
+CC := $(RISCV_PREFIX)gcc
+OBJDUMP := $(RISCV_PREFIX)objdump
+OBJCOPY := $(RISCV_PREFIX)objcopy
+EMU := $(FLEXPRET_ROOT_DIR)/emulator/fp-emu # Verilator C++ emulator
 
-NUM_THREADS ?= 1 # default number of threads
 
 .PHONY: compile riscv dump mem run clean
 
+# Default target; generates the riscv, dump, and mem files
 compile: riscv dump mem
 
+# Compiles a C program into a riscv ELF file.
 riscv: $(NAME).riscv
-%.riscv: *.c
-	$(CC) -I$(LIB_DIR)/include -T $(LINKER_SCRIPT) -Xlinker -Map=output.map \
-     -DNUM_THREADS=$(NUM_THREADS) -g -static -O0 -march=rv32i -mabi=ilp32 \
-     -nostartfiles --specs=nosys.specs -o $*.riscv $(LIB_DIR)/start.S \
-     $(LIB_DIR)/syscalls.c $(LIB_DIR)/tinyalloc/tinyalloc.c $(LIB_DIR)/startup.c \
-     $(LIB_DIR)/flexpret_thread.c $(LIB_DIR)/flexpret_lock.c *.c
+%.riscv: $(LIB_SOURCES) $(APP_SOURCES)
+	$(CC) -I$(LIB_DIR)/include -T $(LINKER_SCRIPT) -Xlinker -Map=$(NAME).map \
+     -DNUM_THREADS=$(NUM_THREADS) $(CFLAGS) -o $*.riscv $^
 
-
+# Generates a dump file for debugging
 dump: $(NAME).dump
 %.dump: %.riscv
-	$(OBJDUMP) -S -d $*.riscv > $*.dump
+	$(OBJDUMP) -S -d $^ > $@
 
-
+# Generates the .mem file, that can be run with fp-emu
 mem: $(NAME).mem
 %.mem: %.riscv
 	$(OBJCOPY) -O binary $*.riscv $*.binary.txt
 	xxd -c 4 -e $*.binary.txt | cut -c11-18 > $*.mem
 	xxd -c 4 -e $*.binary.txt > $*.mem.orig
-	rm $*.binary.txt
+	rm $*.binary.txt # Delete the temporary binary file
 
-
+# runs the program (generated .mem file) using fp-emu 
 run: $(NAME).mem
 	$(EMU) +ispm=$^;
 
-
+# deletes all generated artifacts
 clean:
 	rm -f *.vcd *.mem *.riscv *.map *.out *.dump *.orig

--- a/programs/tests/c-tests/add/Makefile
+++ b/programs/tests/c-tests/add/Makefile
@@ -1,0 +1,3 @@
+FLEXPRET_ROOT_DIR=../../../../
+NAME=add
+include ../../../../Makefrag

--- a/programs/tests/c-tests/add/Makefile
+++ b/programs/tests/c-tests/add/Makefile
@@ -1,3 +1,4 @@
-FLEXPRET_ROOT_DIR=../../../../
-NAME=add
-include ../../../../Makefrag
+FLEXPRET_ROOT_DIR = ../../../../
+NAME = add
+APP_SOURCES = *.c
+include $(FLEXPRET_ROOT_DIR)/Makefrag

--- a/programs/tests/c-tests/calloc/Makefile
+++ b/programs/tests/c-tests/calloc/Makefile
@@ -1,3 +1,4 @@
-FLEXPRET_ROOT_DIR=../../../../
-NAME=calloc
-include ../../../../Makefrag
+FLEXPRET_ROOT_DIR = ../../../../
+NAME = calloc
+APP_SOURCES = *.c
+include $(FLEXPRET_ROOT_DIR)/Makefrag

--- a/programs/tests/c-tests/calloc/Makefile
+++ b/programs/tests/c-tests/calloc/Makefile
@@ -1,0 +1,3 @@
+FLEXPRET_ROOT_DIR=../../../../
+NAME=calloc
+include ../../../../Makefrag

--- a/programs/tests/c-tests/fib/Makefile
+++ b/programs/tests/c-tests/fib/Makefile
@@ -1,3 +1,4 @@
-FLEXPRET_ROOT_DIR=../../../../
-NAME=fib
-include ../../../../Makefrag
+FLEXPRET_ROOT_DIR = ../../../../
+NAME = fib
+APP_SOURCES = *.c
+include $(FLEXPRET_ROOT_DIR)/Makefrag

--- a/programs/tests/c-tests/fib/Makefile
+++ b/programs/tests/c-tests/fib/Makefile
@@ -1,0 +1,3 @@
+FLEXPRET_ROOT_DIR=../../../../
+NAME=fib
+include ../../../../Makefrag

--- a/programs/tests/c-tests/global/Makefile
+++ b/programs/tests/c-tests/global/Makefile
@@ -1,0 +1,3 @@
+FLEXPRET_ROOT_DIR=../../../../
+NAME=global
+include ../../../../Makefrag

--- a/programs/tests/c-tests/global/Makefile
+++ b/programs/tests/c-tests/global/Makefile
@@ -1,3 +1,4 @@
-FLEXPRET_ROOT_DIR=../../../../
-NAME=global
-include ../../../../Makefrag
+FLEXPRET_ROOT_DIR = ../../../../
+NAME = global
+APP_SOURCES = *.c
+include $(FLEXPRET_ROOT_DIR)/Makefrag

--- a/programs/tests/c-tests/gpio/Makefile
+++ b/programs/tests/c-tests/gpio/Makefile
@@ -1,0 +1,3 @@
+FLEXPRET_ROOT_DIR=../../../../
+NAME=gpio
+include ../../../../Makefrag

--- a/programs/tests/c-tests/gpio/Makefile
+++ b/programs/tests/c-tests/gpio/Makefile
@@ -1,3 +1,4 @@
-FLEXPRET_ROOT_DIR=../../../../
-NAME=gpio
-include ../../../../Makefrag
+FLEXPRET_ROOT_DIR = ../../../../
+NAME = gpio
+APP_SOURCES = *.c
+include $(FLEXPRET_ROOT_DIR)/Makefrag

--- a/programs/tests/c-tests/hwlock/Makefile
+++ b/programs/tests/c-tests/hwlock/Makefile
@@ -1,0 +1,3 @@
+FLEXPRET_ROOT_DIR=../../../../
+NAME=hwlock
+include ../../../../Makefrag

--- a/programs/tests/c-tests/hwlock/Makefile
+++ b/programs/tests/c-tests/hwlock/Makefile
@@ -1,3 +1,4 @@
-FLEXPRET_ROOT_DIR=../../../../
-NAME=hwlock
-include ../../../../Makefrag
+FLEXPRET_ROOT_DIR = ../../../../
+NAME = hwlock
+APP_SOURCES = *.c
+include $(FLEXPRET_ROOT_DIR)/Makefrag

--- a/programs/tests/c-tests/lbu/Makefile
+++ b/programs/tests/c-tests/lbu/Makefile
@@ -1,0 +1,3 @@
+FLEXPRET_ROOT_DIR=../../../../
+NAME=lbu
+include ../../../../Makefrag

--- a/programs/tests/c-tests/lbu/Makefile
+++ b/programs/tests/c-tests/lbu/Makefile
@@ -1,3 +1,4 @@
-FLEXPRET_ROOT_DIR=../../../../
-NAME=lbu
-include ../../../../Makefrag
+FLEXPRET_ROOT_DIR = ../../../../
+NAME = lbu
+APP_SOURCES = *.c
+include $(FLEXPRET_ROOT_DIR)/Makefrag

--- a/programs/tests/c-tests/malloc/Makefile
+++ b/programs/tests/c-tests/malloc/Makefile
@@ -1,0 +1,3 @@
+FLEXPRET_ROOT_DIR=../../../../
+NAME=malloc
+include ../../../../Makefrag

--- a/programs/tests/c-tests/malloc/Makefile
+++ b/programs/tests/c-tests/malloc/Makefile
@@ -1,3 +1,4 @@
-FLEXPRET_ROOT_DIR=../../../../
-NAME=malloc
-include ../../../../Makefrag
+FLEXPRET_ROOT_DIR = ../../../../
+NAME = malloc
+APP_SOURCES = *.c
+include $(FLEXPRET_ROOT_DIR)/Makefrag

--- a/programs/tests/c-tests/realloc/Makefile
+++ b/programs/tests/c-tests/realloc/Makefile
@@ -1,0 +1,3 @@
+FLEXPRET_ROOT_DIR=../../../../
+NAME=realloc
+include ../../../../Makefrag

--- a/programs/tests/c-tests/realloc/Makefile
+++ b/programs/tests/c-tests/realloc/Makefile
@@ -1,3 +1,4 @@
-FLEXPRET_ROOT_DIR=../../../../
-NAME=realloc
-include ../../../../Makefrag
+FLEXPRET_ROOT_DIR = ../../../../
+NAME = realloc
+APP_SOURCES = *.c
+include $(FLEXPRET_ROOT_DIR)/Makefrag

--- a/programs/tests/c-tests/syscall/Makefile
+++ b/programs/tests/c-tests/syscall/Makefile
@@ -1,3 +1,4 @@
-FLEXPRET_ROOT_DIR=../../../../
-NAME=syscall
-include ../../../../Makefrag
+FLEXPRET_ROOT_DIR = ../../../../
+NAME = syscall
+APP_SOURCES = *.c
+include $(FLEXPRET_ROOT_DIR)/Makefrag

--- a/programs/tests/c-tests/syscall/Makefile
+++ b/programs/tests/c-tests/syscall/Makefile
@@ -1,0 +1,3 @@
+FLEXPRET_ROOT_DIR=../../../../
+NAME=syscall
+include ../../../../Makefrag


### PR DESCRIPTION
Allows any program to be built by running `make`, and to be run by the emulator using `make run`.

To compile multithreaded programs, the number of threads can be set with
```
make clean && NUM_THREADS=4 make
```
To delete build artifacts, run `make clean`.

The goal of this is to replace the scripts `riscv_clean.sh` and `riscv_compile.sh` in https://github.com/pretis/flexpret/tree/master/scripts/c 
