### PR TITLE
3-state sleep

### DIFF
--- a/src/main/scala/Core/CSR.scala
+++ b/src/main/scala/Core/CSR.scala
@@ -340,6 +340,18 @@ class CSR(implicit val conf: FlexpretConfiguration) extends Module {
     }
   }
 
+  val sleeper = Module(new Sleeper()).io
+  sleeper.tid := 0.U
+  sleeper.wake := false.B
+  sleeper.valid := false.B
+  when (write && compare_addr(CSRs.sleeper)) {
+    sleeper.tid := io.rw.data_in >> 1
+    sleeper.wake := io.rw.data_in(0)
+    sleeper.valid := true.B
+    data_out := sleeper.state
+  }
+
+
   // exception handling
   if (conf.exceptions) {
     when(io.exception) {

--- a/src/main/scala/Core/instructions.scala
+++ b/src/main/scala/Core/instructions.scala
@@ -260,6 +260,7 @@ object CSRs {
   val tohost    = 0x51e
   val fromhost  = 0x51f
   val hwlock    = 0x520
+  val sleeper   = 0x530
   val cycle     = 0xc00
   val time      = 0xc01
   val instret   = 0xc02

--- a/src/main/scala/Core/sleep.scala
+++ b/src/main/scala/Core/sleep.scala
@@ -1,0 +1,50 @@
+package flexpret.core
+
+import chisel3._
+import chisel3.util._
+
+
+
+class SleeperIO(implicit val conf: FlexpretConfiguration) extends Bundle {
+    val valid = Input(Bool())
+    val wake = Input(Bool())
+    val tid = Input(UInt(conf.threadBits.W))
+    val state = Output(UInt(2.W))
+}
+
+
+class Sleeper(implicit val conf: FlexpretConfiguration) extends Module {
+    val io = IO(new SleeperIO())
+    io.state := 3.U // invalid state
+
+    val regAwake = RegInit(0.U(conf.threads.W))
+    val regCaffeinated = RegInit(0.U(conf.threads.W))
+
+    val mask = 1.U(conf.threads.W) << io.tid
+    val awake = (regAwake & mask) =/= 0.U(conf.threads.W)
+    val caffeinated = (regCaffeinated & mask) =/= 0.U(conf.threads.W)
+
+    when(io.valid) {
+        when(io.wake) {
+            when (awake || caffeinated) { // set state to caffeinated
+                regAwake := regAwake & (~mask)
+                regCaffeinated := regCaffeinated | mask
+                io.state := 2.U
+            } .otherwise { // set state to awake
+                regAwake := regAwake | mask
+                regCaffeinated := regCaffeinated & (~mask)
+                io.state := 1.U
+            }
+        }.otherwise {
+            when (caffeinated) { // set state to awake
+                regAwake := regAwake | mask
+                regCaffeinated := regCaffeinated & (~mask)
+                io.state := 1.U
+            } .otherwise { // set state to asleep
+                regAwake := regAwake & (~mask)
+                regCaffeinated := regCaffeinated & (~mask)
+                io.state := 0.U
+            }
+        }
+    }
+}


### PR DESCRIPTION
In order to avoid spinlocks, threads need a mechanism to sleep themselves and wake other threads. This "3-state sleep" allows any thread to be in one of the following states:
 - asleep
 - awake
 - caffeinated: awake, and sleeping this thread will set the state back to awake

The caffeinated state exists so that a thread may sleep, while another thread wakes it, without any fear of race conditions. If the thread sleeps first, then it is awoken by the other thread, then it will sleep, then continue running in the normal/awake state. If the other thread wakes it first, then it sleeps, it will also end up in the normal/awake state.

TODO:
 - modify TMODES register based on sleep state
 - write tests
 - modify threading runtime to take advantage of 3-state sleep 