### PR TITLE
Hold reset high first CC in Verilator emulation

### DIFF
--- a/Makefrag
+++ b/Makefrag
@@ -57,7 +57,7 @@ mem: $(NAME).mem
 
 # runs the program (generated .mem file) using fp-emu 
 run: $(NAME).mem
-	@$(EMU) $^;
+	@$(EMU) +ispm=$^;
 
 # Clean and recompile
 recompile: clean compile

--- a/emulator/main.cpp
+++ b/emulator/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]) {
 
   while (!Verilated::gotFinish()) {
     // Hold reset high the two first clock cycles.
-    if (timestamp <= 2 {
+    if (timestamp <= 2) {
       top->reset = 1;
     } else {
       top->reset = 0;

--- a/emulator/main.cpp
+++ b/emulator/main.cpp
@@ -3,15 +3,14 @@
  * C++ main entry point for Verilator simulation.
  *
  * Copyright 2021 Edward Wang <edwardw@eecs.berkeley.edu>
+ * Copyright 2023 Erling Rennemo Jellum <erling.r.jellum@ntnu.no>
  */
 #include "VVerilatorTop.h"
 #include "verilated.h"
 #include "verilated_vcd_c.h"
 #include <iostream>
 
-
 uint64_t timestamp = 0;
-
 
 double sc_time_stamp() {
   return timestamp;
@@ -29,7 +28,6 @@ int main(int argc, char* argv[]) {
   Verilated::commandArgs(argc, argv);
   Verilated::traceEverOn(true);
 
-
   VVerilatorTop * top = new VVerilatorTop;
   VerilatedVcdC *trace;
   if (trace_enabled) {
@@ -37,11 +35,16 @@ int main(int argc, char* argv[]) {
     top->trace(trace, 99);
     trace->open("trace.vcd");
   }
-  
-
 
   // FIXME: Set this via command-line arguments.
   while (!Verilated::gotFinish()) {
+    // Hold reset high the very first clock cycle.
+    if (timestamp == 0) {
+      top->reset = 1;
+    } else {
+      top->reset = 0;
+    }
+
     top->clock = 1;
     top->eval();
     timestamp++;

--- a/emulator/main.cpp
+++ b/emulator/main.cpp
@@ -36,10 +36,9 @@ int main(int argc, char* argv[]) {
     trace->open("trace.vcd");
   }
 
-  // FIXME: Set this via command-line arguments.
   while (!Verilated::gotFinish()) {
-    // Hold reset high the very first clock cycle.
-    if (timestamp <= 1) {
+    // Hold reset high the two first clock cycles.
+    if (timestamp <= 2 {
       top->reset = 1;
     } else {
       top->reset = 0;

--- a/emulator/main.cpp
+++ b/emulator/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char* argv[]) {
   // FIXME: Set this via command-line arguments.
   while (!Verilated::gotFinish()) {
     // Hold reset high the very first clock cycle.
-    if (timestamp == 0) {
+    if (timestamp <= 1) {
       top->reset = 1;
     } else {
       top->reset = 0;

--- a/programs/lib/startup.c
+++ b/programs/lib/startup.c
@@ -127,12 +127,18 @@ void Reset_Handler() {
         // to wake up and execute up to here,
         // by allocating the slots to them.
         slot_t slots[8];
-        for (int i = 0; i < NUM_THREADS; i++)
+        for (int i = 0; i < NUM_THREADS; i++) {
             slots[i] = i;
+        }
         // Disable slots with ID >= NUM_THREADS,
         for (int j = NUM_THREADS; j < SLOTS_SIZE; j++)
             slots[j] = SLOT_D;
+        
+        // Acquire lock and allow all threads to start execute as HRTTs
         hwlock_acquire();
+        for (int i = 0; i < NUM_THREADS; i++) {
+            tmode_set(i, TMODE_HA);
+        }
         slot_set(slots, 8);
         hwlock_release();
 


### PR DESCRIPTION
Set `reset` to `1` the very first clock cycle during emulation.