### PR TITLE
Cmake single lib

### DIFF
--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -62,16 +62,12 @@ configure_file(
   "$ENV{FP_SDK_PATH}/lib/linker/internal/swconfig.ld"
 )
 
-# Interface library
-add_library(fp-sdk-if INTERFACE)
-
 # Library with source files
 # This is the interface library + source code
-add_library(fp-sdk INTERFACE)
-target_link_libraries(fp-sdk INTERFACE fp-sdk-if)
+add_library(fp-sdk)
 
 # Make sdk dependent on these files so it will detect changes to them
-target_sources(fp-sdk-if INTERFACE ${FP_INSTALLED_FILES})
+target_sources(fp-sdk PRIVATE ${FP_INSTALLED_FILES})
 
 if (${TARGET} STREQUAL "fpga")
   option(DEBUG "Enable or disable debug such as printf" OFF)
@@ -79,7 +75,7 @@ else()
   option(DEBUG "Enable or disable debug such as printf" ON)
 endif()
 
-target_compile_options(fp-sdk-if INTERFACE 
+target_compile_options(fp-sdk PUBLIC 
   # Gives build-time error if the developer attempts to allocate variables on the
   # stack bigger than the stacksize
   "-Werror=stack-usage=${STACKSIZE}"
@@ -92,14 +88,14 @@ target_compile_options(fp-sdk-if INTERFACE
 )
 
 
-target_compile_definitions(fp-sdk-if INTERFACE 
+target_compile_definitions(fp-sdk PUBLIC
   # This is used to check whether the SDK has the same hardware configuration
   # as the built FlexPRET
   FP_CONFIGHASH=0x${CRC32_HASH}
 )
 
 if (NOT ${DEBUG})
-  target_compile_definitions(fp-sdk-if INTERFACE NDEBUG)
+  target_compile_definitions(fp-sdk PUBLIC NDEBUG)
 endif()
 
 add_subdirectory(lib)
@@ -115,7 +111,7 @@ if (PROJECT_IS_TOP_LEVEL)
 endif()
 
 set_property(
-  TARGET fp-sdk-if APPEND PROPERTY
+  TARGET fp-sdk APPEND PROPERTY
   ADDITIONAL_CLEAN_FILES
     "$ENV{FP_SDK_PATH}/lib/include/flexpret/internal/swconfig.h"
     "$ENV{FP_SDK_PATH}/lib/linker/internal/swconfig.ld"

--- a/sdk/bootloader/CMakeLists.txt
+++ b/sdk/bootloader/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(location-empty INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/empty/location.
 target_include_directories(location-empty INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/empty)
 
 # 2. bootloader-first depends on location-empty
-target_link_libraries(bootloader-first location-empty)
+target_link_libraries(bootloader-first PRIVATE location-empty)
 
 # 3. Actual location.h
 add_library(location INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/actual/location.h)
@@ -39,7 +39,7 @@ target_include_directories(location INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/actual
 add_dependencies(location bootloader-first)
 
 # 4. Compile bootloader with location.h
-target_link_libraries(bootloader-second location)
+target_link_libraries(bootloader-second PRIVATE location)
 
 # 5. Verify size and produce bootloader.ld
 # Note: Need to call this target `bootloader` so this target (and its dependencies)
@@ -126,8 +126,8 @@ include($ENV{FP_SDK_PATH}/cmake/fp-app.cmake)
 target_include_directories(bootloader-first PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(bootloader-second PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(bootloader-first fp-sdk)
-target_link_libraries(bootloader-second fp-sdk)
+target_link_libraries(bootloader-first PUBLIC fp-sdk)
+target_link_libraries(bootloader-second PUBLIC fp-sdk)
 
 fp_add_outputs(bootloader-first)
 

--- a/sdk/external/CMakeLists.txt
+++ b/sdk/external/CMakeLists.txt
@@ -40,6 +40,6 @@ target_compile_definitions(printf PUBLIC
   vprintf_=vprintf
 )
 
-target_compile_definitions(fp-sdk-if INTERFACE HAVE_PRINTF)
-target_include_directories(fp-sdk-if INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/printf/src)
-target_link_libraries(fp-sdk INTERFACE printf)
+target_compile_definitions(fp-sdk PUBLIC HAVE_PRINTF)
+target_include_directories(fp-sdk PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/printf/src)
+target_link_libraries(fp-sdk PUBLIC printf)

--- a/sdk/lib/CMakeLists.txt
+++ b/sdk/lib/CMakeLists.txt
@@ -6,7 +6,6 @@ set(SOURCES
   io.c
   lock.c
   pbuf.c
-  printf_putchar.c
   startup.c
   syscalls.c
   thread.c
@@ -16,25 +15,26 @@ set(SOURCES
 
 list(TRANSFORM SOURCES PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/src/")
 
-target_sources(fp-sdk PUBLIC ${SOURCES})
+target_sources(fp-sdk PRIVATE ${SOURCES})
+target_sources(fp-sdk PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/printf_putchar.c)
 
 if (${TARGET} STREQUAL "fpga")
-  target_compile_definitions(fp-sdk-if INTERFACE __FPGA__)
+  target_compile_definitions(fp-sdk PUBLIC __FPGA__)
 else()
-  target_compile_definitions(fp-sdk-if INTERFACE __EMULATOR__)
+  target_compile_definitions(fp-sdk PUBLIC __EMULATOR__)
 endif()
 
-target_compile_definitions(fp-sdk-if INTERFACE 
+target_compile_definitions(fp-sdk PUBLIC 
   _REENT_SMALL 
   ${NEWLIB_REENTRANCY_METHOD} # Set in configderive.cmake
 )
 
-target_include_directories(fp-sdk-if INTERFACE
+target_include_directories(fp-sdk PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>"
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
-target_link_options(fp-sdk-if INTERFACE
+target_link_options(fp-sdk PUBLIC
   "-L" "${CMAKE_CURRENT_SOURCE_DIR}/linker" "-T" "flexpret.ld"
 )

--- a/sdk/tests/c-tests/add/CMakeLists.txt
+++ b/sdk/tests/c-tests/add/CMakeLists.txt
@@ -1,8 +1,7 @@
 set(TESTNAME add)
 
 add_executable(${TESTNAME} ${TESTNAME}.c)
-include(${CMAKE_SOURCE_DIR}/cmake/fp-app.cmake)
-
+include($ENV{FP_SDK_PATH}/cmake/fp-app.cmake)
 target_link_libraries(${TESTNAME} fp-sdk)
 
 fp_add_outputs(${TESTNAME})


### PR DESCRIPTION
Here I am making quick and dirty changes to move to a single library. I am fine with having two targets for the SDK, but I would at least like to know exactly why.

Here several PUBLIC's should be changed to PRIVATE, I was trying to figure out why there was a linker error with _putchar. Turned out to that te printf_putchar.c needed to be visible for the printf-lib