### PR TITLE
Add some DU tests for FlexPRET (.scala tests).

### DIFF
--- a/src/test/scala/core/CSRTest.scala
+++ b/src/test/scala/core/CSRTest.scala
@@ -298,45 +298,4 @@ class CSRTest extends AnyFlatSpec with ChiselScalatestTester {
       }
     }
   }
-
-  it should "check a long delay" in {
-    test(csrDebug).withAnnotations(Seq(treadle.WriteVcdAnnotation)) { c => 
-      timescope {
-        // Set no timeout on clock
-        c.clock.setTimeout(0)
-        
-        val targetTimeNs = 100000
-        val delayTimeNs = 1000
-
-        // Advance clock by a lot; don't use actual clock but instead just
-        // poke the `reg_time` register. This saves a lot of simulation time,
-        // but waveform will be a bit weird
-        c.writeCSR(CSRs.time, targetTimeNs.asUInt)
-
-        c.writeCSR(CSRs.compare_du_wu, (targetTimeNs + delayTimeNs).asUInt)
-
-        // Check initial signals
-        c.io.timer_expire_du_wu(0).expect(true.B)
-        c.io.timer_expire_du_wu(1).expect(true.B)
-        c.io.timer_expire_du_wu(2).expect(true.B)
-        c.io.timer_expire_du_wu(3).expect(true.B)
-
-        // Delay half time and check signals
-        c.clock.step((delayTimeNs / 2) / 10)
-
-        c.io.timer_expire_du_wu(0).expect(false.B)
-        c.io.timer_expire_du_wu(1).expect(true.B)
-        c.io.timer_expire_du_wu(2).expect(true.B)
-        c.io.timer_expire_du_wu(3).expect(true.B)
-
-        // Delay rest and check signals
-        c.clock.step((delayTimeNs / 2) / 10)
-
-        c.io.timer_expire_du_wu(0).expect(true.B)
-        c.io.timer_expire_du_wu(1).expect(true.B)
-        c.io.timer_expire_du_wu(2).expect(true.B)
-        c.io.timer_expire_du_wu(3).expect(true.B)
-      }
-    }
-  }
 }

--- a/src/test/scala/core/CSRTest.scala
+++ b/src/test/scala/core/CSRTest.scala
@@ -65,7 +65,7 @@ class CSRTest extends AnyFlatSpec with ChiselScalatestTester {
 
   val confDebug = FlexpretConfiguration(threads=threads, flex=false, clkFreqMHz=100,
     InstMemConfiguration(bypass=false, sizeKB=512),
-    dMemKB=512, mul=false, priv=true, features="all", debug=true)
+    dMemKB=512, mul=false, priv=true, features="all")
 
   def csrNoPriv = new CSR("h00000000".asUInt(32.W), confNoPriv)
   def csrPriv   = new CSR("h00000000".asUInt(32.W), confPriv)


### PR DESCRIPTION
Some tests I used to start working on issue https://github.com/pretis/flexpret/issues/93, but I might not be able to finish this issue. But I guess just adding a few more tests is not an issue.

The problem with creating tests for that issue is simulation times are massively high if the uppermost bit should be set. So there should be a way to set FlexPRET's internal timer without having to simulate each clock cycle up until that point.