### PR TITLE
Reduce bootloader size

### DIFF
--- a/sdk/bootloader/startup.c
+++ b/sdk/bootloader/startup.c
@@ -51,11 +51,6 @@ void Reset_Handler() {
          */
         application();
     }
-
-
-    // Exit the program.
-    write_tohost(CSR_TOHOST_FINISH);
-    _fp_finish();
     
     // Infinite loop
     while (1);


### PR DESCRIPTION
I had not noticed this before, but the bootloader size was ~5kB due to calls to `write_tohost` which referenced `printf` (not newlib printf, but our low-footprint implementation). Without these calls (which won't work on an FPGA either way), the bootlaoder size is reduced to 1.5kB.