### PR TITLE
ARM-based macOS support & riscv64

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ steps:
   displayName: 'Generate verilog, emulator and install it to SDK'
 - script: |
     # Set environment to find RISC-V compiler
-    export RISCV_TOOL_PATH_PREFIX=~/riscv-embed-gcc
+    export RISCV_TOOL_PATH_PREFIX=/usr
     source env.bash
 
     # Step into SDK and run tests
@@ -40,7 +40,7 @@ steps:
   # debug issues with the job
 - script: |
     # Set environment to find RISC-V compiler
-    export RISCV_TOOL_PATH_PREFIX=~/riscv-embed-gcc
+    export RISCV_TOOL_PATH_PREFIX=/usr
     source env.bash
     
     # Run multiple tests with script

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,13 +15,19 @@ steps:
     # so we do not use 'sudo apt-get install -y -qq verilator' here.
     wget -q https://github.com/sifive/verilator/releases/download/4.036-0sifive2/verilator_4.036-0sifive2_amd64.deb -O verilator.deb
     sudo dpkg -i verilator.deb
-    ## Install RISC-V GCC from source
-    sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev
-    git clone https://github.com/riscv/riscv-gnu-toolchain
-    cd riscv-gnu-toolchain
-    ./configure --prefix=/opt/riscv
-    make
-    which riscv64-unknown-elf-gcc
+    ## Install RISC-V GCC
+    wget -q https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases/download/v8.3.0-2.3/xpack-riscv-none-embed-gcc-8.3.0-2.3-linux-x64.tar.gz -O riscv.tgz
+    tar zxf riscv.tgz
+    mv xpack-riscv-none-embed-gcc-8.3.0-2.3 ~/riscv-embed-gcc
+    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-as ~/riscv-embed-gcc/bin/riscv64-unknown-elf-as
+    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-ar ~/riscv-embed-gcc/bin/riscv64-unknown-elf-ar
+    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-gcc ~/riscv-embed-gcc/bin/riscv64-unknown-elf-gcc
+    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-ld ~/riscv-embed-gcc/bin/riscv64-unknown-elf-ld
+    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-objdump ~/riscv-embed-gcc/bin/riscv64-unknown-elf-objdump
+    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-objcopy ~/riscv-embed-gcc/bin/riscv64-unknown-elf-objcopy
+
+    # Update submodules
+    git submodule update --init --recursive
   displayName: Prereqs
 - script: sbt 'test'
   displayName: 'FlexPRET hardware unit tests'
@@ -29,7 +35,7 @@ steps:
   displayName: 'Generate verilog, emulator and install it to SDK'
 - script: |
     # Set environment to find RISC-V compiler
-    export RISCV_TOOL_PATH_PREFIX=/opt/riscv
+    export RISCV_TOOL_PATH_PREFIX=~/riscv-embed-gcc
     source env.bash
 
     # Step into SDK and run tests
@@ -40,7 +46,7 @@ steps:
   # debug issues with the job
 - script: |
     # Set environment to find RISC-V compiler
-    export RISCV_TOOL_PATH_PREFIX=/opt/riscv
+    export RISCV_TOOL_PATH_PREFIX=~/riscv-embed-gcc
     source env.bash
     
     # Run multiple tests with script

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,19 +10,14 @@ steps:
 # We work around it by running the tests twice (!!!)
 # flexpret.test.compileClasspath java.util.NoSuchElementException: key not found: https://oss.sonatype.org/content/repositories/releases/com/lihaoyi/utest_2.12/maven-metadata.xml
 - script: |
+    ## Install Verilator
     # Ubuntu 20.04 only has Verilator 4.028 but we neeed a more modern version
     # so we do not use 'sudo apt-get install -y -qq verilator' here.
     wget -q https://github.com/sifive/verilator/releases/download/4.036-0sifive2/verilator_4.036-0sifive2_amd64.deb -O verilator.deb
     sudo dpkg -i verilator.deb
-    wget -q https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases/download/v8.3.0-2.3/xpack-riscv-none-embed-gcc-8.3.0-2.3-linux-x64.tar.gz -O riscv.tgz
-    tar zxf riscv.tgz
-    mv xpack-riscv-none-embed-gcc-8.3.0-2.3 ~/riscv-embed-gcc
-    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-as ~/riscv-embed-gcc/bin/riscv32-unknown-elf-as
-    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-ar ~/riscv-embed-gcc/bin/riscv32-unknown-elf-ar
-    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-gcc ~/riscv-embed-gcc/bin/riscv32-unknown-elf-gcc
-    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-ld ~/riscv-embed-gcc/bin/riscv32-unknown-elf-ld
-    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-objdump ~/riscv-embed-gcc/bin/riscv32-unknown-elf-objdump
-    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-objcopy ~/riscv-embed-gcc/bin/riscv32-unknown-elf-objcopy
+    ## Install RISC-V GCC
+    sudo apt update
+    sudo apt install gcc-riscv64-unknown-elf
 
     # Update submodules
     git submodule update --init --recursive

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,13 +15,13 @@ steps:
     # so we do not use 'sudo apt-get install -y -qq verilator' here.
     wget -q https://github.com/sifive/verilator/releases/download/4.036-0sifive2/verilator_4.036-0sifive2_amd64.deb -O verilator.deb
     sudo dpkg -i verilator.deb
-    ## Install RISC-V GCC
-    sudo apt update
-    sudo apt install gcc-riscv64-unknown-elf
+    ## Install RISC-V GCC from source
+    sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev
+    git clone https://github.com/riscv/riscv-gnu-toolchain
+    cd riscv-gnu-toolchain
+    ./configure --prefix=/opt/riscv
+    make
     which riscv64-unknown-elf-gcc
-
-    # Update submodules
-    git submodule update --init --recursive
   displayName: Prereqs
 - script: sbt 'test'
   displayName: 'FlexPRET hardware unit tests'
@@ -29,7 +29,7 @@ steps:
   displayName: 'Generate verilog, emulator and install it to SDK'
 - script: |
     # Set environment to find RISC-V compiler
-    export RISCV_TOOL_PATH_PREFIX=/usr
+    export RISCV_TOOL_PATH_PREFIX=/opt/riscv
     source env.bash
 
     # Step into SDK and run tests
@@ -40,7 +40,7 @@ steps:
   # debug issues with the job
 - script: |
     # Set environment to find RISC-V compiler
-    export RISCV_TOOL_PATH_PREFIX=/usr
+    export RISCV_TOOL_PATH_PREFIX=/opt/riscv
     source env.bash
     
     # Run multiple tests with script

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ steps:
     ## Install RISC-V GCC
     wget -q https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v14.2.0-2/xpack-riscv-none-elf-gcc-14.2.0-2-linux-x64.tar.gz -O riscv.tgz
     tar zxf riscv.tgz
-    ls xpack-riscv-none-elf-gcc-14.2.0-2
+    ls xpack-riscv-none-elf-gcc-14.2.0-2/bin
     mv xpack-riscv-none-elf-gcc-14.2.0-2 ~/riscv-embed-gcc
     ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-as ~/riscv-embed-gcc/bin/riscv64-unknown-elf-as
     ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-ar ~/riscv-embed-gcc/bin/riscv64-unknown-elf-ar

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,9 +16,10 @@ steps:
     wget -q https://github.com/sifive/verilator/releases/download/4.036-0sifive2/verilator_4.036-0sifive2_amd64.deb -O verilator.deb
     sudo dpkg -i verilator.deb
     ## Install RISC-V GCC
-    wget -q https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases/download/v8.3.0-2.3/xpack-riscv-none-embed-gcc-8.3.0-2.3-linux-x64.tar.gz -O riscv.tgz
+    wget -q https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v14.2.0-2/xpack-riscv-none-elf-gcc-14.2.0-2-linux-x64.tar.gz -O riscv.tgz
     tar zxf riscv.tgz
-    mv xpack-riscv-none-embed-gcc-8.3.0-2.3 ~/riscv-embed-gcc
+    ls xpack-riscv-none-elf-gcc-14.2.0-2
+    mv xpack-riscv-none-elf-gcc-14.2.0-2 ~/riscv-embed-gcc
     ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-as ~/riscv-embed-gcc/bin/riscv64-unknown-elf-as
     ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-ar ~/riscv-embed-gcc/bin/riscv64-unknown-elf-ar
     ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-gcc ~/riscv-embed-gcc/bin/riscv64-unknown-elf-gcc

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,7 @@ steps:
     ## Install RISC-V GCC
     sudo apt update
     sudo apt install gcc-riscv64-unknown-elf
+    which riscv64-unknown-elf-gcc
 
     # Update submodules
     git submodule update --init --recursive

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,12 +20,12 @@ steps:
     tar zxf riscv.tgz
     ls xpack-riscv-none-elf-gcc-14.2.0-2/bin
     mv xpack-riscv-none-elf-gcc-14.2.0-2 ~/riscv-embed-gcc
-    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-as ~/riscv-embed-gcc/bin/riscv64-unknown-elf-as
-    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-ar ~/riscv-embed-gcc/bin/riscv64-unknown-elf-ar
-    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-gcc ~/riscv-embed-gcc/bin/riscv64-unknown-elf-gcc
-    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-ld ~/riscv-embed-gcc/bin/riscv64-unknown-elf-ld
-    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-objdump ~/riscv-embed-gcc/bin/riscv64-unknown-elf-objdump
-    ln -s ~/riscv-embed-gcc/bin/riscv-none-embed-objcopy ~/riscv-embed-gcc/bin/riscv64-unknown-elf-objcopy
+    ln -s ~/riscv-embed-gcc/bin/riscv-none-elf-as ~/riscv-embed-gcc/bin/riscv64-unknown-elf-as
+    ln -s ~/riscv-embed-gcc/bin/riscv-none-elf-ar ~/riscv-embed-gcc/bin/riscv64-unknown-elf-ar
+    ln -s ~/riscv-embed-gcc/bin/riscv-none-elf-gcc ~/riscv-embed-gcc/bin/riscv64-unknown-elf-gcc
+    ln -s ~/riscv-embed-gcc/bin/riscv-none-elf-ld ~/riscv-embed-gcc/bin/riscv64-unknown-elf-ld
+    ln -s ~/riscv-embed-gcc/bin/riscv-none-elf-objdump ~/riscv-embed-gcc/bin/riscv64-unknown-elf-objdump
+    ln -s ~/riscv-embed-gcc/bin/riscv-none-elf-objcopy ~/riscv-embed-gcc/bin/riscv64-unknown-elf-objcopy
 
     # Update submodules
     git submodule update --init --recursive

--- a/emulator/main.cpp
+++ b/emulator/main.cpp
@@ -150,7 +150,7 @@ int main(int argc, char* argv[]) {
     }
 
     if (trace_enabled) {
-      trace->dump(10*timestamp);
+      trace->dump(static_cast<vluint64_t>(10*timestamp));
     }
 
     if (pin_client_enabled) {

--- a/fpga/zedboard/fp-blinky/CMakeLists.txt
+++ b/fpga/zedboard/fp-blinky/CMakeLists.txt
@@ -11,7 +11,7 @@ add_custom_target(${TARGET_NAME} DEPENDS
     "${CMAKE_CURRENT_BINARY_DIR}/bitstream.bit"
 )
 
-set(ISPM_FILE $ENV{FP_PATH}/apps/build/blinky/blinky.mem)
+set(ISPM_FILE $ENV{FP_PATH}/apps/blinky/build/blinky.mem)
 
 # We want to include these commands because we do not want to type them out
 # for each FPGA project

--- a/sdk/cmake/riscv-toolchain.cmake
+++ b/sdk/cmake/riscv-toolchain.cmake
@@ -13,13 +13,14 @@ cmake_minimum_required(VERSION 3.13)
 # because they are appended to already existing flags
 include_guard(GLOBAL)
 
-set(CMAKE_SYSTEM_PROCESSOR riscv)
+set(CMAKE_SYSTEM_NAME Generic)  # Explicitly set for cross-compilation
+set(CMAKE_SYSTEM_PROCESSOR riscv64)
 set(RISCV_HOST_TAG linux)
 
 set(RISCV_TOOL_PATH $ENV{RISCV_TOOL_PATH_PREFIX} CACHE PATH "RISC-V tool path" FORCE)
 
 set(RISCV_TOOLCHAIN_ROOT "${RISCV_TOOL_PATH}/bin" CACHE PATH "RISC-V compiler path")
-set(RISCV_TOOLCHAIN_PREFIX "riscv32-unknown-elf-" CACHE STRING "RISC-V toolchain prefix")
+set(RISCV_TOOLCHAIN_PREFIX "riscv64-unknown-elf-" CACHE STRING "RISC-V toolchain prefix")
 set(CMAKE_FIND_ROOT_PATH ${RISCV_TOOLCHAIN_ROOT})
 list(APPEND CMAKE_PREFIX_PATH "${RISCV_TOOLCHAIN_ROOT}")
 
@@ -29,14 +30,19 @@ set(CMAKE_STRIP "${RISCV_TOOLCHAIN_ROOT}/${RISCV_TOOLCHAIN_PREFIX}strip")
 set(CMAKE_OBJDUMP "${RISCV_TOOLCHAIN_ROOT}/${RISCV_TOOLCHAIN_PREFIX}objdump")
 set(CMAKE_OBJCOPY "${RISCV_TOOLCHAIN_ROOT}/${RISCV_TOOLCHAIN_PREFIX}objcopy")
 
-set(RISCV_COMPILER_FLAGS "-g -Os -static -march=rv32i -mabi=ilp32 -nostartfiles --specs=nosys.specs -ffunction-sections -fdata-sections -Wl,--gc-sections")
+set(RISCV_COMPILER_FLAGS "-g -Os -static -march=rv32i_zicsr -mabi=ilp32 -nostartfiles --specs=nosys.specs -ffunction-sections -fdata-sections -Wl,--gc-sections")
 set(RISCV_COMPILER_FLAGS_CXX)
 set(RISCV_COMPILER_FLAGS_DEBUG)
 set(RISCV_COMPILER_FLAGS_RELEASE)
 set(RISCV_LINKER_FLAGS)
 set(RISCV_LINKER_FLAGS_EXE "" CACHE STRING "Linker flags for RISCV executables")
 
-set(CMAKE_SYSTEM_PROCESSOR riscv32)
+# Check if the current OS is macOS
+if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin")
+  # Override macOS-specific settings
+  set(CMAKE_OSX_ARCHITECTURES "")
+  set(CMAKE_OSX_SYSROOT "")
+endif()
 
 set(CMAKE_C_FLAGS             "${RISCV_COMPILER_FLAGS} ${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_FLAGS           "${RISCV_COMPILER_FLAGS} ${RISCV_COMPILER_FLAGS_CXX} ${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
This PR fixes a few errors when building FlexPRET on ARM-based Mac:
1. In `main.cpp`, explicitly casting `10*timestamp` to `vluint64_t` removes an error raised by clang.
2. In `CMakeLists.txt`, a path problem is fixed so that blinky could build again using instructions in the README.
3. In `riscv-toolchain.cmake`, a check is added to remove Mac-specific compile flags added by CMake.

Also, in `riscv-toolchain.cmake`, `riscv64-` is used for all gnu tools, because `riscv64-` is now the mainstream toolchain. `riscv32-` seems deprecated by the RISC-V team.

This PR also updates the CI script to invoke the xpack GCC using the same command as the one for `riscv64-` gcc.