### PR TITLE
Get correct script path for macOS

### DIFF
--- a/env.bash
+++ b/env.bash
@@ -1,8 +1,22 @@
 #!/usr/bin/env bash
 
 # From https://stackoverflow.com/questions/59895/how-do-i-get-the-directory-where-a-bash-script-is-located-from-within-the-script 
-FLEXPRET_ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# The top solution does not work on macOS.
+# The solution below comes from this answer: https://stackoverflow.com/a/179231
+pushd . > '/dev/null';
+SCRIPT_PATH="${BASH_SOURCE[0]:-$0}";
 
+while [ -h "$SCRIPT_PATH" ];
+do
+    cd "$( dirname -- "$SCRIPT_PATH"; )";
+    SCRIPT_PATH="$( readlink -f -- "$SCRIPT_PATH"; )";
+done
+
+cd "$( dirname -- "$SCRIPT_PATH"; )" > '/dev/null';
+SCRIPT_PATH="$( pwd; )";
+popd  > '/dev/null';
+
+FLEXPRET_ROOT=$SCRIPT_PATH
 export PATH="$FLEXPRET_ROOT/build/emulator:$PATH"
 export FP_PATH="$FLEXPRET_ROOT"
 export FP_SDK_PATH="$FLEXPRET_ROOT/sdk"


### PR DESCRIPTION
This PR fixes `env.bash` for macOS. The issue was, when this script was sourced, an incorrect path was returned instead of the directory containing the script. This PR fixes that.